### PR TITLE
Add "-debugger" option to wide. Automatically open/lock/debug provided path

### DIFF
--- a/src/wide/ActionsProvider.wx
+++ b/src/wide/ActionsProvider.wx
@@ -100,6 +100,7 @@ Class ActionsProvider
 		CreateAction( ActionId.Run,"Ctrl+R" )
 		CreateAction( ActionId.Semant,"Ctrl+C" )
 		CreateAction( ActionId.Debug,"Ctrl+D" )
+		CreateAction( ActionId.DebugDesktop,"" )
 		CreateAction( ActionId.ForceStop,"Ctrl+Shift+R" )
 		CreateAction( ActionId.ProductSettings,"" )
 		CreateAction( ActionId.NextError,"F4" )
@@ -173,6 +174,7 @@ Class ActionsProvider
 		CreateAction( ActionId.Run,"F5" )
 		CreateAction( ActionId.Semant,"F7" )
 		CreateAction( ActionId.Debug,"F8" )
+		CreateAction( ActionId.DebugDesktop,"" )
 		CreateAction( ActionId.ForceStop,"Shift+F5" )
 		CreateAction( ActionId.ProductSettings,"" )
 		CreateAction( ActionId.NextError,"F4" )
@@ -251,6 +253,7 @@ Class ActionId Final
 	Const Run:="run"
 	Const Semant:="check"
 	Const Debug:="debug"
+	Const DebugDesktop:="debug_desktop"
 	Const ForceStop:="force_stop"
 	Const ProductSettings:="product_settings"
 	Const NextError:="next_error"

--- a/src/wide/ActionsProvider.wx
+++ b/src/wide/ActionsProvider.wx
@@ -100,7 +100,6 @@ Class ActionsProvider
 		CreateAction( ActionId.Run,"Ctrl+R" )
 		CreateAction( ActionId.Semant,"Ctrl+C" )
 		CreateAction( ActionId.Debug,"Ctrl+D" )
-		CreateAction( ActionId.DebugDesktop,"" )
 		CreateAction( ActionId.ForceStop,"Ctrl+Shift+R" )
 		CreateAction( ActionId.ProductSettings,"" )
 		CreateAction( ActionId.NextError,"F4" )
@@ -174,7 +173,6 @@ Class ActionsProvider
 		CreateAction( ActionId.Run,"F5" )
 		CreateAction( ActionId.Semant,"F7" )
 		CreateAction( ActionId.Debug,"F8" )
-		CreateAction( ActionId.DebugDesktop,"" )
 		CreateAction( ActionId.ForceStop,"Shift+F5" )
 		CreateAction( ActionId.ProductSettings,"" )
 		CreateAction( ActionId.NextError,"F4" )
@@ -253,7 +251,6 @@ Class ActionId Final
 	Const Run:="run"
 	Const Semant:="check"
 	Const Debug:="debug"
-	Const DebugDesktop:="debug_desktop"
 	Const ForceStop:="force_stop"
 	Const ProductSettings:="product_settings"
 	Const NextError:="next_error"

--- a/src/wide/action/BuildActions.wx
+++ b/src/wide/action/BuildActions.wx
@@ -39,7 +39,6 @@ Class BuildActions Implements IModuleBuilder
 
 	Field buildAndRun:Action
 	Field debugApp:Action
-	Field debugDesktopApp:Action
 	Field build:Action
 	Field semant:Action
 	Field buildSettings:Action
@@ -69,9 +68,6 @@ Class BuildActions Implements IModuleBuilder
 		
 		debugApp=ActionById( ActionId.Debug )
 		debugApp.Triggered=OnDebugApp
-
-		debugDesktopApp=ActionById( ActionId.DebugDesktop )
-		debugDesktopApp.Triggered=OnDebugDesktopApp
 
 		build=ActionById( ActionId.Build )
 		build.Triggered=OnBuild
@@ -588,14 +584,6 @@ Class BuildActions Implements IModuleBuilder
 		BuildApp( "debug",_buildTarget,"run" )
 	End
 
-	Method OnDebugDesktopApp()
-		PreBuild()
-
-		If _console.Running Return
-
-		BuildApp( "debug", "desktop", "run" )
-	End
-	
 	Method OnBuild()
 		
 		PreBuild()

--- a/src/wide/action/BuildActions.wx
+++ b/src/wide/action/BuildActions.wx
@@ -39,6 +39,7 @@ Class BuildActions Implements IModuleBuilder
 
 	Field buildAndRun:Action
 	Field debugApp:Action
+	Field debugDesktopApp:Action
 	Field build:Action
 	Field semant:Action
 	Field buildSettings:Action
@@ -68,6 +69,9 @@ Class BuildActions Implements IModuleBuilder
 		
 		debugApp=ActionById( ActionId.Debug )
 		debugApp.Triggered=OnDebugApp
+
+		debugDesktopApp=ActionById( ActionId.DebugDesktop )
+		debugDesktopApp.Triggered=OnDebugDesktopApp
 
 		build=ActionById( ActionId.Build )
 		build.Triggered=OnBuild
@@ -582,6 +586,14 @@ Class BuildActions Implements IModuleBuilder
 		If _console.Running Return
 	
 		BuildApp( "debug",_buildTarget,"run" )
+	End
+
+	Method OnDebugDesktopApp()
+		PreBuild()
+
+		If _console.Running Return
+
+		BuildApp( "debug", "desktop", "run" )
 	End
 	
 	Method OnBuild()

--- a/src/wide/wide.wx
+++ b/src/wide/wide.wx
@@ -242,20 +242,44 @@ Function Main()
 	Endif
 	
 	New MainWindowInstance( AppTitle,rect,flags,jobj )
-	
+
+	'add callback when app is ready
 	App.Idle+=Lambda()
-		
-		' open docs from args
+	    'read app args and process various modes
 		Local args:=AppArgs()
-		For Local i:=1 Until args.Length
-			Local arg:=args[i]
-			arg=arg.Replace( "\","/" )
-			MainWindow.OnFileDropped( arg )
-		Next
+
+        If args <> Null And args.Length >= 2
+            Select args[1]
+                Case "-debugger"
+                    If args.Length < 3
+                        'App.Terminate()
+                    EndIf
+
+                    'check for no path specified
+                    Local path := args[2].Replace( "\","/" )
+                    If path = Null Or path.Length = 0 Or Not FileExists(path)
+                        'App.Terminate()
+                    EndIf
+
+                    'open & switch to the specified document
+                    'also lock the build file
+                    MainWindow.OpenDocument(path, True)
+
+                    'trigger debug
+                    ActionById(ActionId.DebugDesktop).Trigger()
+
+                Default
+                    'otherwise just open all of the docs specified in args
+                    For Local i:=1 Until args.Length
+                        Local arg:=args[i]
+                        arg=arg.Replace( "\","/" )
+                        MainWindow.OnFileDropped( arg )
+                    Next
+            End
+        EndIf
 		
 		#If __TARGET__="macos"
 		App.Idle+=Lambda() ' quick fix for black screen on mojave at startup
-			
 			Local dx:=MainWindow.Frame.Left Mod 2 = 0 ? -1 Else 1
 			MainWindow.Frame=MainWindow.Frame+New Recti( dx,0,0,0 )
 			MainWindow.RequestRender()
@@ -266,7 +290,6 @@ Function Main()
 	SDL_EnableScreenSaver()
 	
 	App.Run()
-	
 End
 
 Function SetupWonkeyRootPath:String( rootPath:String,searchMode:Bool )

--- a/src/wide/wide.wx
+++ b/src/wide/wide.wx
@@ -252,13 +252,13 @@ Function Main()
             Select args[1]
                 Case "-debugger"
                     If args.Length < 3
-                        'App.Terminate()
+                        App.Terminate()
                     EndIf
 
                     'check for no path specified
                     Local path:=args[2].Replace( "\","/" )
-                    If path = Null Or path.Length = 0 Or Not FileExists(path)
-                        'App.Terminate()
+                    If path = Null And path.Length And FileExists(path)
+                        App.Terminate()
                     EndIf
 
                     'open & switch to the specified document

--- a/src/wide/wide.wx
+++ b/src/wide/wide.wx
@@ -256,7 +256,7 @@ Function Main()
                     EndIf
 
                     'check for no path specified
-                    Local path := args[2].Replace( "\","/" )
+                    Local path:=args[2].Replace( "\","/" )
                     If path = Null Or path.Length = 0 Or Not FileExists(path)
                         'App.Terminate()
                     EndIf
@@ -266,7 +266,7 @@ Function Main()
                     MainWindow.OpenDocument(path, True)
 
                     'trigger debug
-                    ActionById(ActionId.DebugDesktop).Trigger()
+                    ActionById( ActionId.Debug ).Trigger()
 
                 Default
                     'otherwise just open all of the docs specified in args


### PR DESCRIPTION
Hi I have been tinkering with wonkey again. I am still die hard monkey person. We actually adopted it 5+ years ago and put huge amounts of resources building it out to be a suitable development platform. Anyways...

Heres a pull request for a small feature. You can launch wide with:
`wide -debugger "file.wx"`

It will open, lock and start debugging the file. It only uses the built in actions/features of wide. There could potnetially be better implementation. For example it could be interesting to add a "debugger" layout to wide that limits the UI for a single debug session. So hide a ton of the projects, toolbars, etc. 

The use case? Well I have been using webstorm to do monkey dev. I have a textmate bundle and just setup some run configs. For example here is a run config to debug a .wx file using wide:
`open -n -a /Users/skn3/Documents/dev/wonkey/bin/macos/wide.app --args -debugger "/Users/skn3/Documents/dev/projects/wonkey/helloworld/helloworld2.wx"`

The -n switch allowing for multiple copies of wide to be open!

Obviously it would be cleaner to creat a custom debug parser for intellij, but thats for another day if ever!