### PR TITLE
List and Stacks improvements

### DIFF
--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -1,5 +1,5 @@
 
-Namespace stdlib.collections
+Namespace std.collections
 
 #rem wonkeydoc Convenience type alias for List\<Int\>.
 #end

--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -739,7 +739,7 @@ Class List<T> Implements IContainer<T>
 		AddFirst(n)
 	End 
 
-	#rem wonkeydoc Same than RemoveFirst, but return nothing.
+	#rem wonkeydoc Same than RemoveFirst
 
 	@param value The value to add to the list.
 

--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -1384,4 +1384,3 @@ Class List<T> Implements IContainer<T>
 		Return result
 	End 
 End
-

--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -1,5 +1,5 @@
 
-Namespace std.collections
+Namespace stdlib.collections
 
 #rem wonkeydoc Convenience type alias for List\<Int\>.
 #end
@@ -101,7 +101,7 @@ Class List<T> Implements IContainer<T>
 		This method should not be used while iterating over the list containing this node or `node`.
 		
 		#end
-		Method InsertBefore( node:Node )
+		Method InsertBefore( node:Node ) Virtual 
 			Remove()
 			'insert
 			_succ=node
@@ -117,13 +117,20 @@ Class List<T> Implements IContainer<T>
 		This method should not be used while iterating over the list containing this node or `node`.
 		
 		#end
-		Method InsertAfter( node:Node )
+		Method InsertAfter( node:Node ) Virtual 
 			Remove()
 			'insert
 			_pred=node
 			_succ=node._succ
 			_succ._pred=Self
 			node._succ=Self
+		End
+		
+		'hidden
+		Method RemoveFast() 'added by iDkP
+			'No bound checking - Pure Pointer manipulation
+			_pred._succ = _succ
+			_succ._pred = _pred
 		End
 		
 	End
@@ -336,39 +343,7 @@ Class List<T> Implements IContainer<T>
 	Property Empty:Bool()
 		Return _head._succ=_head
 	End
-	
-	#rem wonkeydoc Counts the number of values in the list.
-	
-	Note: This method can be slow when used with large lists, as it must visit each value. If you just
-	want to know whether a list is empty or not, use [[Empty]] instead.
 
-	@return The number of values in the list.
-	
-	#end
-	Method Count:UInt() 'iDkP: UNSIGNED 32 bits!
-		Local node:=_head._succ,n:=0
-		While node<>_head
-			node=node._succ
-			n+=1
-		Wend
-		Return n
-	End
-	
-	#rem wonkeydoc Converts the list to an array.
-	
-	@return An array containing the items in the list.
-	
-	#end
-	Method ToArray:T[]()
-		Local n:=Count()
-		Local data:=New T[n],node:=_head._succ
-		For Local i:=0 Until n
-			data[i]=node._value
-			node=node._succ
-		Next
-		Return data
-	End
-	
 	#rem wonkeydoc Gets the first value in the list.
 	
 	In debug builds, a runtime error will occur if the list is empty.
@@ -395,6 +370,445 @@ Class List<T> Implements IContainer<T>
 		Return _head._pred._value
 	End
 	
+	'---- iDkP added: HasOne, HasTwo, HasOneOrTwo, HasMore, HasLess ----
+
+	#rem wonkeydoc Test if the list has only one element
+	
+	@return False if the list's empty of has more one elements.
+	
+	@return True if the list has exactly one element.
+	
+	#end
+	Property HasOne:Bool() 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		' Return true if the list has one item (no more)
+		'
+		Return _head._succ=_head ? ( _head._succ<>_head._pred ? True Else False ) Else False
+	End
+
+	#rem wonkeydoc Test if the list has exactly two elements
+	
+	@return False if the list's empty of has one or more two elements.
+	
+	@return True if the list has exactly two elements.
+	
+	#end
+	Property HasTwo:Bool() 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		' Return true if the list has two items (no more)
+		'
+		Return _head._succ=_head ? ( _head._succ=_head._pred ? True Else False ) Else False
+	End
+
+	#rem wonkeydoc Test if the list has one or two elements
+	
+	@return -1 if the last's 'some elements' but empty, one or two elements
+	
+	@return 0 if the list's empty
+	
+	@return 1 if the list has exactly one element.
+	
+	@return 2 if the list has exactly two elements.
+	
+	#end	
+	Property HasOneOrTwo:Byte() 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		' Returns...
+		'	-1 = neither empty, 1 or 2 (meaning 'has more than two and is not empty')
+		'	0 = empty
+		'	1 = 1 item
+		'	2 = 2 items
+		' Empty is tested at the 3th step because... 
+		' if you suppose the list empty, you want only make sure about that: use Empty;
+		' using HasOneOrTwo, you make the hypothesis that the list isn't empty, you just
+		' want to know if the list has one or two elements, or maybe more.
+		'
+		Return HasOne ? 1 Else ( HasTwo ? 2 Else ( Empty ? -1 Else 0 ) )
+	End 	
+
+	#rem wonkeydoc Returns if the list has less than n items.
+	
+	Note: This method can be slow when used with large lists, as it must visit each value.
+	But if the method count until nbItems, it will stop counting and returns the answer.
+	So it's faster than using Count() if we want only know if the list has less than nbItems.
+
+	@return True if the list has less items than nbItems' value.
+	
+	#end
+	Method HasLess:Bool( nbItems:UInt ) 'Added by iDkP
+		'iDkP 2025-05-13
+		Local node:=_head._succ,n:=0
+		While node<>_head Or n<nbItems
+			node=node._succ
+			n+=1
+		Wend
+		Return n<nbItems
+	End 
+
+	#rem wonkeydoc Returns if the list has more than n items.
+	
+	Note: This method can be slow when used with large lists, as it must visit each value.
+	But if the method count above nbItems, it will stop counting and returns the answer.
+	So it's faster than using Count() if we want only know if the list has more than nbItems.
+
+	@return True if the list has more items than nbItems' value.
+	
+	#end
+	Method HasMore:Bool( nbItems:UInt ) 'Added by iDkP
+		'iDkP 2025-05-13
+		Local result:Bool=True
+		Local node:=_head._succ,n:=0
+		While node<>_head
+			node=node._succ
+			If n>nbItems 
+				result=False 
+				Exit 
+			End 
+			n+=1
+		Wend
+		Return result
+	End 
+	
+	'---- iDkP added: To:Map, ToMapByte, ToMapUByte, ToMapInt, ToMapUInt, ToMapLong, ToMapULong, FromMap ----
+
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	The value is prefilled with an index that you can override after.
+	
+	As the key is unique, the index (as map's value) is also unique.
+	If you want make the value set to Null (smallest memory print), use ToMap methods instead.
+	
+	@return The new map as Map<T,UInt>
+	
+	#end
+	Operator To:Map<T,UInt>() 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-10
+		'
+		'Let's say, alternated version, where the list item become the map key 
+		'(map as a set: only one occurance accepted)
+		'
+		Local map:=New Map<T,UInt>()
+		Local offset:UInt=0
+		For Local item:=Eachin Self
+			map.Set(item,offset)
+			offset+=1
+		End
+		Return map
+	End
+	
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	defValue will populate the new values of the map.
+	You can populate with an index if you prefere.
+	
+	@param deValue the default value who will populate the map as Value
+	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range -128,128.
+	
+	@return The new map as Map<T,Byte>
+	
+	#end
+	Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		' Let's say, alternated version, where the list item become the map key 
+		' Special version with lighter memory print, 
+		' for specific usage where the value isn't important (smallest datatype)
+		' and if Byte must contains negative values (-128,128)
+		' (map as a set: only one occurance accepted)
+		#rem Bug 
+			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+		#end 
+		'
+		Local map:=New Map<T,Byte>()
+		If populateWithIdx 
+			Local offset:Byte=-128
+			For Local item:=Eachin Self
+				map.Set(item,offset)
+				offset+=1
+			End
+		Else 
+			For Local item:=Eachin Self
+				map.Set(item,defValue)
+			End
+		End 
+		Return map
+	End
+
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	defValue will populate the new values of the map.
+	You can populate with an index if you prefere.
+	
+	@param deValue the default value who will populate the map as Value
+	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,255.
+	
+	@return The new map as Map<T,UByte>
+	
+	#end
+	Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		' Let's say, alternated version, where the list item become the map key 
+		' Special version with lighter memory print, 
+		' for specific usage where the value isn't important (smallest datatype)
+		' and if Byte must contains negative values (0,255)
+		' (map as a set: only one occurance accepted)
+		#rem Bug 
+			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+		#end 
+		'
+		Local map:=New Map<T,UByte>()
+		If populateWithIdx 
+			Local offset:UByte=0
+			For Local item:=Eachin Self
+				map.Set(item,offset)
+				offset+=1
+			End
+		Else 
+			For Local item:=Eachin Self
+				map.Set(item,defValue)
+			End
+		End 
+		Return map
+	End
+
+	#rem wonkeydoc Made a list from the map's values.
+	Explicitly declare your List type as same than your map's value's type to set up the overloading.
+	Note: Map must has a different type of key from value.
+	
+	@param onPlace if False, returns a copy of the list, else operates on the list directly.
+	
+	@return a copy of the list if onPlace=False
+	
+	#end	
+	Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
+		result = onPlace ? Self Else Copy()
+		result.Clear()
+		For Local item:=Eachin map 
+			result.Add(item)
+		End 
+		Return result
+	End
+
+	#rem wonkeydoc Made a list from the map's keys.
+	Explicitly declare your List type as same than your map's key's type to set up the overloading.
+	Note: Map must has a different type of key from value.
+	
+	@param onPlace if False, returns a copy of the list, else operates on the list directly.
+	
+	@return a copy of the list if onPlace=False
+	
+	#end
+	Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
+		result = onPlace ? Self Else Copy()
+		result.Clear()
+		For Local item:=Eachin map .Key
+			result.Add(item)
+		End 
+		Return result
+	End
+
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	defValue will populate the new values of the map.
+	You can populate with an index if you prefere.
+	
+	@param deValue the default value who will populate the map as Value
+	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range -2147483648,2147483648.
+	
+	@return The new map as Map<T,UByte>
+	
+	#end
+	Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		'Let's say, normal version, where the list item become the map value
+		#rem Bug 
+			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+		#end 
+		Local map:=New Map<Int,T>()
+		If populateWithIdx 
+			Local offset:Int=-2147483648 'TODO, change for the const
+			For Local item:=Eachin Self
+				map.Set(offset,item)
+				offset+=1
+			End
+		Else 
+			For Local item:=Eachin Self
+				map.Set(defValue,item)
+			End
+		End 
+		Return map
+	End
+
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	defValue will populate the new values of the map.
+	You can populate with an index if you prefere.
+	
+	@param deValue the default value who will populate the map as Value
+	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,4294967296.
+	
+	@return The new map as Map<T,UByte>
+	
+	#end
+	Method ToMapUInt:Map<UInt,T>( defValue:UInt=Null, populateWithIdx:Bool=False ) 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		'Let's say, normal version, where the list item become the map value
+		#rem Bug 
+			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+		#end 
+		Local map:=New Map<UInt,T>()
+		If populateWithIdx 
+			Local offset:UInt=0
+			For Local item:=Eachin Self
+				map.Set(offset,item)
+				offset+=1
+			End
+		Else 
+			For Local item:=Eachin Self
+				map.Set(defValue,item)
+			End
+		End 
+		Return map
+	End
+
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	defValue will populate the new values of the map.
+	You can populate with an index if you prefere.
+	
+	@param deValue the default value who will populate the map as Value
+	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range -9223372036854775808,9223372036854775808.
+	
+	@return The new map as Map<T,UByte>
+	
+	#end
+	Method ToMapLong:Map<Long,T>( defValue:Long=Null, populateWithIdx:Bool=False ) 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		'Let's say, normal version, where the list item become the map value
+		#rem Bug 
+			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+		#end 
+		Local map:=New Map<Long,T>()
+		If populateWithIdx 
+			Local offset:UInt=0
+			For Local item:=Eachin Self
+				map.Set(offset,item)
+				offset+=1
+			End
+		Else 
+			For Local item:=Eachin Self
+				map.Set(defValue,item)
+			End
+		End 
+		Return map
+	End
+
+	#rem wonkeydoc Cast the list intro a map where the map's key are the list's elements.
+	
+	defValue will populate the new values of the map.
+	You can populate with an index if you prefere.
+	
+	@param deValue the default value who will populate the map as Value
+	
+	@param populateWithIdx if True, the map's values will be populated with a index in the range 0,18446744073709551615.
+	
+	@return The new map as Map<T,UByte>
+	
+	#end
+	Method ToMapULong:Map<ULong,T>( defValue:ULong=Null, populateWithIdx:Bool=False ) 'Added by iDkP
+		'
+		' iDkP from GaragePixel
+		' 2025-05-11
+		'
+		'Let's say, normal version, where the list item become the map value
+		#rem Bug 
+			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
+			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756
+		#end 
+		Local map:=New Map<ULong,T>()
+		If populateWithIdx 
+			Local offset:UInt=0
+			For Local item:=Eachin Self
+				map.Set(offset,item)
+				offset+=1
+			End
+		Else 
+			For Local item:=Eachin Self
+				map.Set(defValue,item)
+			End
+		End 
+		Return map
+	End
+
+	#rem wonkeydoc Counts the number of values in the list.
+	
+	Note: This method can be slow when used with large lists, as it must visit each value. If you just
+	want to know whether a list is empty or not, use [[Empty]] instead.
+
+	@return The number of values in the list.
+	
+	#end
+	Method Count:UInt() 'iDkP: UNSIGNED 32 bits!
+		Local node:=_head._succ,n:=0
+		While node<>_head
+			node=node._succ
+			n+=1
+		Wend
+		Return n
+	End
+	
+	#rem wonkeydoc Converts the list to an array.
+	
+	@return An array containing the items in the list.
+	
+	#end
+	Method ToArray:T[]() ' Updated by iDkP
+		'iDkP: Pseudo operator, deprecated
+'		Return Self 
+		Local n:=Count()
+		Local data:=New T[n],node:=_head._succ
+		For Local i:=0 Until n
+			data[i]=node._value
+			node=node._succ
+		Next
+		Return data
+	End
+	
 	#rem wonkeydoc Removes all values from the list.
 	
 	#end
@@ -410,7 +824,7 @@ Class List<T> Implements IContainer<T>
 	@return A new node containing the value.
 
 	#end
-	Method AddFirst:Node( value:T )
+	Method AddFirst:Node( value:T ) Virtual 
 		Local node:=New Node( value,_head._succ )
 		Return node
 	End
@@ -422,7 +836,7 @@ Class List<T> Implements IContainer<T>
 	@return A new node containing the value.
 
 	#end
-	Method AddLast:Node( value:T )
+	Method AddLast:Node( value:T ) Virtual 
 		Local node:=New Node( value,_head )
 		Return node
 	End
@@ -706,15 +1120,13 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Return a copy of the list
-
 	@return Copy of the list
-
 	#end
 	Method Copy:List<T>() 'Added by iDkP from GaragePixel
 		'Added for consistency (there is an operator to copy a list, 
 		'but it is not obvious for a new user of the library)
 		Return New List<T>( Self )
-	End
+	End	
 
 	'----------------------------------------------
 	' Extension: List As Queue
@@ -731,18 +1143,14 @@ Class List<T> Implements IContainer<T>
 	'----------------------------------------------
 
 	#rem wonkeydoc Same than AddFirst, but return nothing.
-
 	@param value The value to add to the list.
-
 	#end
 	Method Enqueue(n:T)
 		AddFirst(n)
 	End 
 
-	#rem wonkeydoc Same than RemoveFirst
-
+	#rem wonkeydoc Same than RemoveFirst, but return nothing.
 	@param value The value to add to the list.
-
 	#end	
 	Method Dequeue:T()
 		Return RemoveFirst()
@@ -751,276 +1159,113 @@ Class List<T> Implements IContainer<T>
 	'----------------------------------------------
 	' Mini-library: Set (math) functions with List
 	' 2025-05-10 - Added by iDkP from GaragePixel
-	'
-	' MakeUnique, MakeUniqueFast, MakeUniqueType
-	' Contains, Append, Union, Intersect, Diff
 	'----------------------------------------------
-		
-	#rem wonkeydoc Make the items (only internal type accepted) of the list unique, keep the original order. 
+	' 
+	' Contains, Append, Union, Intersect, Diff, Dedup
+	'
+	'	Suggested use cases:
+	'
+	'	- Game development: Entity management, feature detection
+	'	- Data processing: Record merging, filtering, deduplication
+	'	- Search systems: Result combination, intersection filtering
+	'	- Access control: Permission calculation, exclusion filtering	
+	'
+	'	Description & Performance characteristics:
+	'
+	'		- Append
+	'			Combines two lists preserving all elements including duplicates (fastest)
+	'			Ultra-fast pointer manipulation (25-50M elements/second)
+	'
+	'		- Union 
+	'			Merges two lists removing duplicates (set union operation)
+	'			Efficient hash-based deduplication (600K-1.4M elements/second)
+	'
+	'		- Intersect
+	'			Creates list containing only elements present in both input lists
+	'			Fast set intersection (600K-1.6M elements/second)
+	'
+	'		- Diff
+	'			Creates list containing elements from first list not present in second
+	'			Optimized difference operation (500K-1.1M elements/second)
+	'
+	'		- Dedup
+	'			Removes duplicate elements from a single list
+	'			Compute 100K elements in 79-148ms (25M-50M elements/second)	
+	'
+	'----------------------------------------------
 
+	#rem wonkeydoc Make the list's items unique. 
 	@param onPlace If False, return a copy of the List
-
 	@return Copy of the list or Null
-
 	#end
-	Method MakeUnique:List<T>(onPlace:Bool=True) Where T=IReal Or T=INumeric Or T=String Or T=Byte Or T=Bool Or T=Variant 'Added by iDkP from GaragePixel
-		
+	Method Dedup:List<T>( onPlace:Bool=True )
+		'
 		' iDkP from GaragePixel
-		' 2025-05-10 - Original algorithm for stdlib: 
-		' https://github.com/GaragePixel/stdlib-for-mx2/tree/main
+		' 2025-05-11
 		'
-		' Note: 
-		'	- The algorithm uses a 32 bit enumerator, it's okay
-		' 	- Hyper fast algorithm using the red-black tree implementation of map (see note under)
-		' 	Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
+		' Note:
+		'	"Dedup" for "Deduplicate"
 		'
-		' Info:
-		'	In MaxScript, there was a function called MakeUniqueName() 
-		'	to ensure that a node was instantiated with a unique label. 
-		'	You can now enjoy that with this language.
-
-		Local map:=New Map<T,UInt>() 'Hash Key calculated from the T value, value as 32 bit marked
-		Local listItem:List<T>.Node=FirstNode() 'A node from List
-		Local listValue:T 'A value from List
-		Local value:UInt '32 bit marker
-		Local result:=New List<T> 'pruned list
-		Local op:UInt 'The list is defined as quasicircular (no root, but floating head) so we need a tracker
-		
-		'Map the values and note how many times they appear in the list
-		Repeat
-			
-			listValue=map.Get(listItem.Value)
-			
-			If listValue<>Null
-				map.Set(listItem.Value,map.Get(listItem.Value)+1)
-			End
-			
-			listItem=listItem.Succ
-			op+=1
-			
-		Until listItem=HeadNode()
-		
-		'As a backward iteration, put the value marked 1 in the result list, otherwise decrement
-		listItem=LastNode()
-		Repeat
-			
-			value=map.Get(listItem.Value)
-			
-			If value=1
-				result.AddFirst(listItem.Value)
-			Else 
-				map.Set(listItem.Value,value-1)
-			End 
-			
-			listItem=listItem.Pred
-			op-=1
-			
-		Until op=0
-		
-		'Finaly, if onPlace, set the actual self
-		
-		If onPlace 
-		
-			'As an extension, the self list should be refilled
-'			Clear() 
-'			For Local i:=Eachin result 
-'				Add(result.FindNode(i).Value)
-'			End
-
-			'But since the method was integrated, we can directly set self
-			_head=result._head
-			
-			Return Null
-			
-		' Else return Result if not onPlace
-		End
-		
-		Return result
-	End 
-
-	#rem wonkeydoc Make the items (only internal type accepted) of the list unique, 
-
-	but do not keep the original order (faster).
-
-	@param onPlace If False, return a copy of the List
-
-	@return Copy of the list or Null
-
-	#end
-	Method MakeUniqueFast:List<T>(onPlace:Bool=True) Where T=IReal Or T=INumeric Or T=String Or T=Byte Or T=Bool Or T=Variant 'Added by iDkP from GaragePixel
-		
-		'iDkP from GaragePixel
-		'2025-05-10 - Original algorithm for stdlib: 
-		'https://github.com/GaragePixel/stdlib-for-mx2/tree/main
-		'
-		' Note: 
-		' 	- Hyper fast algorithm using the red-black tree implementation of map (see note under)
-		' 	Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
-		'
-		' 	- This method only takes internal type because:
-		' 		- To make a key from map, the type must be an internal type, not a custom type,
-		'
-		'	- Do not need to be output in the exact same order from the input
-		'
-		' Info:
-		'	In MaxScript, there was a function called MakeUniqueName()
-		'	to ensure that a node was instantiated with a unique label. 
-		'	You can now enjoy that with this language. If the item's order
-		'	don't makes a deal, you can use this faster version of MakeUnique().
-
-		Local map:=New Map<T,T>() 'Hash Key calculated from the T value, value as T
-		Local listItem:List<T>.Node=FirstNode() 'A node from List
-		Local result:=New List<T> 'pruned list
-		
-		'Put in the map the list's values (will be set one time by value)
-		Repeat
-			
-			map.Set(listItem.Value,listItem.Value)
-			listItem=listItem.Succ
-			
-		Until listItem=HeadNode()
-		
-		'Retrieve the map's values:
-		
-		'Finaly, if onPlace, set the actual self
-		If onPlace 
-		
-			Clear()
-			For Local n:=Eachin map
-				Add(n.Value)
-			Next
-			
-			Return Null
-		End 
-			
-		'Else return Result if not onPlace
-		For Local n:=Eachin map
-			result.Add(n.Value)
-		Next
-		
-		Return result
-	End
-
-	#rem wonkeydoc Make the items (any custom type accepted) of the list unique, keep the original order.
-
-	@param onPlace if False, return a copy of the List
-
-	@return Copy of the list or Null
-
-	#end
-	Method MakeUniqueType:List<T>(onPlace:Bool=True) 'Added by iDkP from GaragePixel
-
-		' iDkP from GaragePixel
-		' 2025-05-11 - Original algorithm
-
 		Local currList:= onPlace ? Self Else Copy()
 		
-		Local count:=currList.Count()
-		If count=1 Return currList
+		Local atLeastTwo:=currList.HasOneOrTwo
+		If atLeastTwo=1 Return currList
 		
 		Local firstNode:List<T>.Node=currList.FirstNode()
 
-		If count=2
-			If firstNode.Value=firstNode.Succ.Value
-				firstNode.Succ.Remove()
-				Return currList
-			Else 
-				Return currList
-			End 
+		If atLeastTwo=2
+			If firstNode.Value=firstNode.Succ.Value firstNode.Succ.Remove()
+			Return currList
 		End 
 
-		'Global loop
-		Local node:=firstNode 'Used to parse the list. Because FirstNode() has a guard we don't want, we call it only one time
-		Local nodeItem:=firstNode 'Current treated item
-		Local nodeToCompare:=firstNode 'Second item to compare with the current treated item
-		Local lastNode:=currList.LastNode() 'memoirize that
+		Local seen:= New Map<T,UByte> 	'We don't care of anything but the red-black tree algorithm, 
+										'so we use the most little datatype: Ubyte for the smallest memory print:
+										'Using UByte (1 or 0) is more memory-efficient as it consumes only 1 byte per entry 
+										'compared to Null which takes 4-8 bytes on most platforms, 
+										'plus UByte avoids reference-related overhead and GC pressure.
+		Local current:= _head._succ
 		
-		'Inner loop
-		Local occurance:UInt '32 bits - count the number of duplicates in a list for the on-going treated item
-		Local actCount:=count '32 bits - active count, keep track of the number of items
-		Local lp:UInt=count+1 '32 bits - loop left, sets on the active count
-		Local comps:UInt '32 bits - used for the matching loop
-		Local op:UInt '32 bits - used for counting the deletions to perform
-		
-		'Speed up
-		Local lastHead:=lastNode '32 bits - used to stick the head on the last duplicate detected
-		Local lastCnt:UInt '32 bits - used to calculate the head from the number of planned deletions
-
-		Repeat
-
-			occurance=0
-			nodeToCompare=firstNode
-			comps=actCount
-			
-			lastCnt=0
-			Repeat
-				
-				'we need to compare the node's value, where T could be from any type
-				If nodeToCompare.Value=nodeItem.Value 
-					occurance+=1
-					lastHead=nodeToCompare
-					lastCnt-=1
-				End
-				nodeToCompare=nodeToCompare.Succ
-				comps-=1
-				lastCnt+=1
-
-			Until comps=0
-			
-			If occurance>1
-
-				op=count-lastCnt
-				node=lastHead
-
-				Repeat
-					'same than above, we need to compare the node's value, where T could be from any type
-					If node.Value=nodeItem.Value
-						node=node.Pred						
-						node.Succ.Remove()
-						occurance-=1
-						actCount-=1
-						op-=1
-						lp-=1
-					End 
-
-					node=node.Pred
-					op-=1
-
-				Until op=1 Or occurance=1 'Stop without checking the whole list if we know it was the last one duplicate
-
-			End 
-
-			nodeItem=nodeItem.Succ
-
-		lp-=1
-		Until lp=0
-
-		Return currList
-	End
+		While current <> _head
+			Local foo:= current._succ
+			If seen.Contains(current._value)
+				' Remove duplicate
+				current.Remove()
+			Else
+				' Mark as seen
+				seen.Set(current._value, 1)
+			End
+			current = foo
+		Wend
+		'Return currList 'Let's say, for consistancy within the library, that we returns 'Null' if OnPlace
+		Return onPlace ? Null Else currList
+	End 
 
 	#rem wonkeydoc Finds the first node in the list containing a value.
-
 	@param value The value to find.
-
 	@return The first node containing the value, or null if the value was not found.
-
 	#end	
 	Method Contains:Node( value:T ) 'Added by iDkP from GaragePixel
-		'iDkP: Added as sugar for front-end consistance with map
+		'iDkP: Added as sugar for consistance with map
 		Return FindNode(value)
 	End
 
 	#rem wonkeydoc Add each keys from this (param) to self
-
 	@param This is the list to compare.
-
 	@param onPlace if False, returns a copy of the list, else nothing
-
 	#end
-	Method Append:List<T>(this:List<T>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
-		'Sugar
+	Method Append:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
+		'
+		' iDkP from GaragePixel
+		' 2025-05-10
+		'
+		' Semi-sugar
+		'
+		' Note:
+		'	Optimisation statut: Append operates at near-direct memory transfer speeds
+		'	Achieves 33 million elements/second for 100K elements
+		'
 		If onPlace 
-			Self.AddAll(this)
+			AddAll(this)
 			Return Null
 		End
 		Local result:=Copy()
@@ -1029,188 +1274,114 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Add each item from this (param) that exist in self. 
-
 	Each item will be unique and in the same order from the two original lists. 
-
 	Note: Make also unique the items in the two original list.
-
 	@param This The list to compare.
-
 	@param onPlace if False, returns a copy of the list, else nothing
-
 	#end	
-	Method Union:List<T>(this:List<T>,onPlace:Bool=True) Where T=IReal Or T=INumeric Or T=String Or T=Byte Or T=Bool Or T=Variant 'Added by iDkP from GaragePixel
+	Method Union:List<T>( this:List<T>,onPlace:Bool=True ) 'Added by iDkP from GaragePixel
 		'
 		' iDkP from GaragePixel
 		' 2025-05-10 - Original algorithm for stdlib: 
 		' https://github.com/GaragePixel/stdlib-for-mx2/tree/main
 		'
 		' Description:
-		' 	Add this to self, do not keep doublons in the output list.
+		' 	Add this to self, do not keep duplicates in the output list.
 		'
 		' Note:
-		' 	Hyper fast algorithm using the red-black tree implementation of map (see note under)
+		' 	- Hyper fast algorithm using the red-black tree implementation of map (see note under)
 		'		Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
-		'
-		' 	This method only takes internal type because:
-		' 		- To make a key from map, the type must be an internal type, not a custom type
-		'
+		' 	- Statut implementation: Union maintains excellent performance
+		' 		Achieves 558K-1M elements/second for 100K elements
+		'		25% duplication: 558,000 elements/second
+		'		50% duplication: 606,000 elements/second
+		'		75% duplication: 840,000 elements/second
+		' 	Append is 40x faster than Union at 100K elements
+		' 	This performance difference aligns with theoretical expectations.
+		
 		If onPlace 
-			Self.AddAll(this)
-
-			'--------------------------
-			'
-			'Strange bug:  
-			'	Can't find overload for 'MakeUnique' with argument types (monkey.types.Bool)
-			'
-			'Return MakeUnique(True) 'Strange bug:  Can't find overload for 'MakeUnique' with argument types (monkey.types.Bool)
-			'
-			'--------------------------
-
-			' Need to un-inlined because the strange bug
-			Local map:=New Map<T,UInt>() 'Hash Key calculated from the T value, value as 32 bit marked
-			Local listItem:List<T>.Node=FirstNode() 'A node from List
-			Local listValue:T 'A value from List
-			Local value:UInt '32 bit marker
-			Local out:=New List<T> 'pruned list
-			Local op:UInt 'The list is defined as quasicircular (no root, but floating head) so we need a tracker
-			
-			'Map the values and note how many times they appear in the list
-			Repeat
-				
-				listValue=map.Get(listItem.Value)
-				
-				If listValue<>Null
-					map.Set(listItem.Value,map.Get(listItem.Value)+1)
-				End
-				
-				listItem=listItem.Succ
-				op+=1
-				
-			Until listItem=HeadNode()
-			
-			'As a backward iteration, put the value marked 1 in the out list, otherwise decrement
-			listItem=LastNode()
-			Repeat
-				
-				value=map.Get(listItem.Value)
-				
-				If value=1
-					out.AddFirst(listItem.Value)
-				Else 
-					map.Set(listItem.Value,value-1)
-				End 
-				
-				listItem=listItem.Pred
-				op-=1
-				
-			Until op=0
-			
-			'Finaly, directly set self
-			_head=out._head
-				
+			AddAll( this )
+			Dedup()
 			Return Null
+		End
 			
-		End 'onPlace version
-		
 		'------------------------- "returns a copy of the list" Version
-		
+			
 		Local result:=Copy()
-		result.AddAll(this)
-
-		'--------------------------
-		'
-		'Strange bug:  
-		'	Can't find overload for 'MakeUnique' with argument types (monkey.types.Bool)
-		'
-		'result.MakeUnique(True) 
-		'Return result
-		'--------------------------
-
-		' Need to un-inlined because the strange bug
-		Local map:=New Map<T,UInt>() 'Hash Key calculated from the T value, value as 32 bit marked
-		Local listItem:List<T>.Node=result.FirstNode() 'A node from List
-		Local listValue:T 'A value from List
-		Local value:UInt '32 bit marker
-		Local out:=New List<T> 'pruned list
-		Local op:UInt 'The list is defined as quasicircular (no root, but floating head) so we need a tracker
-		
-		'Map the values and note how many times they appear in the list
-		Repeat
-			
-			listValue=map.Get(listItem.Value)
-			
-			If listValue<>Null
-				map.Set(listItem.Value,map.Get(listItem.Value)+1)
-			End
-			
-			listItem=listItem.Succ
-			op+=1
-			
-		Until listItem=result.HeadNode()
-		
-		'As a backward iteration, put the value marked 1 in the out list, otherwise decrement
-		listItem=result.LastNode()
-		Repeat
-			
-			value=map.Get(listItem.Value)
-			
-			If value=1
-				out.AddFirst(listItem.Value)
-			Else 
-				map.Set(listItem.Value,value-1)
-			End 
-			
-			listItem=listItem.Pred
-			op-=1
-			
-		Until op=0
-		
-		'Finaly, return result
-		Return out
+		result.AddAll( this )
+		result.Dedup()
+		Return result
 	End
 
 	#rem wonkeydoc Keep all keys from self that exist in this (param)
-
 	@param This is the list to compare.
-
 	@param onPlace if False, returns a copy of the list, else nothing
-
 	#end	
-	Method Intersect:List<T>(this:List<T>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
-		'Keep in self the keys that exist in this
-		If onPlace 
-			For Local item:= Eachin Self
-				If this.FindNode(item)=Null Self.RemoveEach(item)
+	Method Intersect:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
+		'
+		' iDkP from GaragePixel
+		' 2025-05-12
+		'
+		' Keep in self the keys that exist in this
+		'
+		' Note:
+		'	Statut implementation: Approach theorical limits for hash-based set operations
+		
+		Local map:=ToMapUByte()
+		Local otherMap:=this.ToMapUByte()
+		Local result:=New List<T>()
+			
+		' Add only items that exist in both lists
+		Local itemKey:T 'memoirize -> small earned micro-seconds 
+		For Local item:= Eachin map
+			itemKey=item.Key
+			If otherMap.Contains(itemKey)
+				result.Add(itemKey)
 			End
+		End
+		If onPlace 
+			_head=result._head
 			Return Null
 		End 
-		Local result:=Copy()
-		For Local item:= Eachin result
-			If this.FindNode(item)=Null result.RemoveEach(item)
-		End 	
-		Return result	
+		
+		Return result
 	End
 
 	#rem wonkeydoc Remove all keys from self that exist in this (param)
-
 	@param This is the list to compare.
-
 	@param onPlace if False, returns a copy of the list, else nothing
-
 	#end
 	Method Diff:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
-		'Remove all keys from self that exist in this
-		If onPlace 
-			For Local item:= Eachin Self
-				If this.FindNode(item)<>Null Self.RemoveEach(item)
+		'
+		' iDkP from GaragePixel
+		' 2025-05-12
+		'
+		' Remove all keys from self that exist in this
+		'
+		' Note: 
+		'	Statut implementation: Approach theorical limits for hash-based set operations, 
+		' 	scaling linearly with collection size 
+		' 	while maintaining throughput in the 495K-813K elements/second range 
+		' 	for large collections.
+		
+		Local map:=ToMapUByte()
+		Local otherMap:=this.ToMapUByte()
+		Local result:=New List<T>()
+			
+		' Add only items that do not exist in the same time in both lists
+		Local itemKey:T 'memoirize -> small earned micro-seconds 
+		For Local item:= Eachin map
+			itemKey=item.Key
+			If Not otherMap.Contains(itemKey)
+				result.Add(itemKey)
 			End
+		End
+		If onPlace 
+			_head=result._head
 			Return Null
 		End 
-		Local result:=Copy()
-		For Local item:= Eachin result
-			If this.FindNode(item)<>Null result.RemoveEach(item)
-		End 	
-		Return result		
-	End
+		
+		Return result
+	End 
 End
+

--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -408,7 +408,7 @@ Class List<T> Implements IContainer<T>
 
 	#rem wonkeydoc Test if the list has one or two elements
 	
-	@return -1 if the last's 'some elements' but empty, one or two elements
+	@return -1 if the list's 'some elements' but empty, one or two elements
 	
 	@return 0 if the list's empty
 	

--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -345,7 +345,7 @@ Class List<T> Implements IContainer<T>
 	@return The number of values in the list.
 	
 	#end
-	Method Count:Int()
+	Method Count:UInt() 'iDkP: UNSIGNED 32 bits!
 		Local node:=_head._succ,n:=0
 		While node<>_head
 			node=node._succ
@@ -903,7 +903,7 @@ Class List<T> Implements IContainer<T>
 
 	#rem wonkeydoc Make the items (any custom type accepted) of the list unique, keep the original order.
 
-	@param onPlace If False, return a copy of the List
+	@param onPlace if False, return a copy of the List
 
 	@return Copy of the list or Null
 
@@ -944,7 +944,7 @@ Class List<T> Implements IContainer<T>
 		
 		'Speed up
 		Local lastHead:=lastNode '32 bits - used to stick the head on the last duplicate detected
-		Local lastCnt:UInt '32 bits - used to calculate the head from the number of programmed deletions
+		Local lastCnt:UInt '32 bits - used to calculate the head from the number of planned deletions
 
 		Repeat
 
@@ -975,9 +975,9 @@ Class List<T> Implements IContainer<T>
 				Repeat
 					'same than above, we need to compare the node's value, where T could be from any type
 					If node.Value=nodeItem.Value
-						node=node.Pred
-						occurance-=1
+						node=node.Pred						
 						node.Succ.Remove()
+						occurance-=1
 						actCount-=1
 						op-=1
 						lp-=1
@@ -986,7 +986,7 @@ Class List<T> Implements IContainer<T>
 					node=node.Pred
 					op-=1
 
-				Until op=1 Or occurance=1 'Stop without checking the whole list if we know it was the last one
+				Until op=1 Or occurance=1 'Stop without checking the whole list if we know it was the last one duplicate
 
 			End 
 
@@ -999,8 +999,11 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Finds the first node in the list containing a value.
+
 	@param value The value to find.
+
 	@return The first node containing the value, or null if the value was not found.
+
 	#end	
 	Method Contains:Node( value:T ) 'Added by iDkP from GaragePixel
 		'iDkP: Added as sugar for front-end consistance with map
@@ -1008,8 +1011,11 @@ Class List<T> Implements IContainer<T>
 	End
 
 	#rem wonkeydoc Add each keys from this (param) to self
-	@param This The list to compare.
+
+	@param This is the list to compare.
+
 	@param onPlace if False, returns a copy of the list, else nothing
+
 	#end
 	Method Append:List<T>(this:List<T>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Sugar
@@ -1047,7 +1053,7 @@ Class List<T> Implements IContainer<T>
 		'		Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
 		'
 		' 	This method only takes internal type because:
-		' 		- To make a key from map, the type must be an internal type, not a custom type,
+		' 		- To make a key from map, the type must be an internal type, not a custom type
 		'
 		If onPlace 
 			Self.AddAll(this)
@@ -1166,7 +1172,7 @@ Class List<T> Implements IContainer<T>
 
 	#rem wonkeydoc Keep all keys from self that exist in this (param)
 
-	@param This The list to compare.
+	@param This is the list to compare.
 
 	@param onPlace if False, returns a copy of the list, else nothing
 
@@ -1188,7 +1194,7 @@ Class List<T> Implements IContainer<T>
 
 	#rem wonkeydoc Remove all keys from self that exist in this (param)
 
-	@param This The list to compare.
+	@param This is the list to compare.
 
 	@param onPlace if False, returns a copy of the list, else nothing
 

--- a/modules/std/collections/list.wx
+++ b/modules/std/collections/list.wx
@@ -704,5 +704,507 @@ Class List<T> Implements IContainer<T>
 		Wend
 		Return Null
 	End
-	
+
+	#rem wonkeydoc Return a copy of the list
+
+	@return Copy of the list
+
+	#end
+	Method Copy:List<T>() 'Added by iDkP from GaragePixel
+		'Added for consistency (there is an operator to copy a list, 
+		'but it is not obvious for a new user of the library)
+		Return New List<T>( Self )
+	End
+
+	'----------------------------------------------
+	' Extension: List As Queue
+	' iDkP from GaragePixel
+	' 2024-11
+	'
+	' List with the Queue instructions' set
+	'
+	' Note: 
+	'	Should we use Deque to implement a similar instruction set?	
+	'
+	'	FIFO Operations:
+	'		Possible usage of the list as queue is the implementation of BFS (Breadth-First Search).
+	'----------------------------------------------
+
+	#rem wonkeydoc Same than AddFirst, but return nothing.
+
+	@param value The value to add to the list.
+
+	#end
+	Method Enqueue(n:T)
+		AddFirst(n)
+	End 
+
+	#rem wonkeydoc Same than RemoveFirst, but return nothing.
+
+	@param value The value to add to the list.
+
+	#end	
+	Method Dequeue:T()
+		Return RemoveFirst()
+	End
+
+	'----------------------------------------------
+	' Mini-library: Set (math) functions with List
+	' 2025-05-10 - Added by iDkP from GaragePixel
+	'
+	' MakeUnique, MakeUniqueFast, MakeUniqueType
+	' Contains, Append, Union, Intersect, Diff
+	'----------------------------------------------
+		
+	#rem wonkeydoc Make the items (only internal type accepted) of the list unique, keep the original order. 
+
+	@param onPlace If False, return a copy of the List
+
+	@return Copy of the list or Null
+
+	#end
+	Method MakeUnique:List<T>(onPlace:Bool=True) Where T=IReal Or T=INumeric Or T=String Or T=Byte Or T=Bool Or T=Variant 'Added by iDkP from GaragePixel
+		
+		' iDkP from GaragePixel
+		' 2025-05-10 - Original algorithm for stdlib: 
+		' https://github.com/GaragePixel/stdlib-for-mx2/tree/main
+		'
+		' Note: 
+		'	- The algorithm uses a 32 bit enumerator, it's okay
+		' 	- Hyper fast algorithm using the red-black tree implementation of map (see note under)
+		' 	Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
+		'
+		' Info:
+		'	In MaxScript, there was a function called MakeUniqueName() 
+		'	to ensure that a node was instantiated with a unique label. 
+		'	You can now enjoy that with this language.
+
+		Local map:=New Map<T,UInt>() 'Hash Key calculated from the T value, value as 32 bit marked
+		Local listItem:List<T>.Node=FirstNode() 'A node from List
+		Local listValue:T 'A value from List
+		Local value:UInt '32 bit marker
+		Local result:=New List<T> 'pruned list
+		Local op:UInt 'The list is defined as quasicircular (no root, but floating head) so we need a tracker
+		
+		'Map the values and note how many times they appear in the list
+		Repeat
+			
+			listValue=map.Get(listItem.Value)
+			
+			If listValue<>Null
+				map.Set(listItem.Value,map.Get(listItem.Value)+1)
+			End
+			
+			listItem=listItem.Succ
+			op+=1
+			
+		Until listItem=HeadNode()
+		
+		'As a backward iteration, put the value marked 1 in the result list, otherwise decrement
+		listItem=LastNode()
+		Repeat
+			
+			value=map.Get(listItem.Value)
+			
+			If value=1
+				result.AddFirst(listItem.Value)
+			Else 
+				map.Set(listItem.Value,value-1)
+			End 
+			
+			listItem=listItem.Pred
+			op-=1
+			
+		Until op=0
+		
+		'Finaly, if onPlace, set the actual self
+		
+		If onPlace 
+		
+			'As an extension, the self list should be refilled
+'			Clear() 
+'			For Local i:=Eachin result 
+'				Add(result.FindNode(i).Value)
+'			End
+
+			'But since the method was integrated, we can directly set self
+			_head=result._head
+			
+			Return Null
+			
+		' Else return Result if not onPlace
+		End
+		
+		Return result
+	End 
+
+	#rem wonkeydoc Make the items (only internal type accepted) of the list unique, 
+
+	but do not keep the original order (faster).
+
+	@param onPlace If False, return a copy of the List
+
+	@return Copy of the list or Null
+
+	#end
+	Method MakeUniqueFast:List<T>(onPlace:Bool=True) Where T=IReal Or T=INumeric Or T=String Or T=Byte Or T=Bool Or T=Variant 'Added by iDkP from GaragePixel
+		
+		'iDkP from GaragePixel
+		'2025-05-10 - Original algorithm for stdlib: 
+		'https://github.com/GaragePixel/stdlib-for-mx2/tree/main
+		'
+		' Note: 
+		' 	- Hyper fast algorithm using the red-black tree implementation of map (see note under)
+		' 	Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
+		'
+		' 	- This method only takes internal type because:
+		' 		- To make a key from map, the type must be an internal type, not a custom type,
+		'
+		'	- Do not need to be output in the exact same order from the input
+		'
+		' Info:
+		'	In MaxScript, there was a function called MakeUniqueName()
+		'	to ensure that a node was instantiated with a unique label. 
+		'	You can now enjoy that with this language. If the item's order
+		'	don't makes a deal, you can use this faster version of MakeUnique().
+
+		Local map:=New Map<T,T>() 'Hash Key calculated from the T value, value as T
+		Local listItem:List<T>.Node=FirstNode() 'A node from List
+		Local result:=New List<T> 'pruned list
+		
+		'Put in the map the list's values (will be set one time by value)
+		Repeat
+			
+			map.Set(listItem.Value,listItem.Value)
+			listItem=listItem.Succ
+			
+		Until listItem=HeadNode()
+		
+		'Retrieve the map's values:
+		
+		'Finaly, if onPlace, set the actual self
+		If onPlace 
+		
+			Clear()
+			For Local n:=Eachin map
+				Add(n.Value)
+			Next
+			
+			Return Null
+		End 
+			
+		'Else return Result if not onPlace
+		For Local n:=Eachin map
+			result.Add(n.Value)
+		Next
+		
+		Return result
+	End
+
+	#rem wonkeydoc Make the items (any custom type accepted) of the list unique, keep the original order.
+
+	@param onPlace If False, return a copy of the List
+
+	@return Copy of the list or Null
+
+	#end
+	Method MakeUniqueType:List<T>(onPlace:Bool=True) 'Added by iDkP from GaragePixel
+
+		' iDkP from GaragePixel
+		' 2025-05-11 - Original algorithm
+
+		Local currList:= onPlace ? Self Else Copy()
+		
+		Local count:=currList.Count()
+		If count=1 Return currList
+		
+		Local firstNode:List<T>.Node=currList.FirstNode()
+
+		If count=2
+			If firstNode.Value=firstNode.Succ.Value
+				firstNode.Succ.Remove()
+				Return currList
+			Else 
+				Return currList
+			End 
+		End 
+
+		'Global loop
+		Local node:=firstNode 'Used to parse the list. Because FirstNode() has a guard we don't want, we call it only one time
+		Local nodeItem:=firstNode 'Current treated item
+		Local nodeToCompare:=firstNode 'Second item to compare with the current treated item
+		Local lastNode:=currList.LastNode() 'memoirize that
+		
+		'Inner loop
+		Local occurance:UInt '32 bits - count the number of duplicates in a list for the on-going treated item
+		Local actCount:=count '32 bits - active count, keep track of the number of items
+		Local lp:UInt=count+1 '32 bits - loop left, sets on the active count
+		Local comps:UInt '32 bits - used for the matching loop
+		Local op:UInt '32 bits - used for counting the deletions to perform
+		
+		'Speed up
+		Local lastHead:=lastNode '32 bits - used to stick the head on the last duplicate detected
+		Local lastCnt:UInt '32 bits - used to calculate the head from the number of programmed deletions
+
+		Repeat
+
+			occurance=0
+			nodeToCompare=firstNode
+			comps=actCount
+			
+			lastCnt=0
+			Repeat
+				
+				'we need to compare the node's value, where T could be from any type
+				If nodeToCompare.Value=nodeItem.Value 
+					occurance+=1
+					lastHead=nodeToCompare
+					lastCnt-=1
+				End
+				nodeToCompare=nodeToCompare.Succ
+				comps-=1
+				lastCnt+=1
+
+			Until comps=0
+			
+			If occurance>1
+
+				op=count-lastCnt
+				node=lastHead
+
+				Repeat
+					'same than above, we need to compare the node's value, where T could be from any type
+					If node.Value=nodeItem.Value
+						node=node.Pred
+						occurance-=1
+						node.Succ.Remove()
+						actCount-=1
+						op-=1
+						lp-=1
+					End 
+
+					node=node.Pred
+					op-=1
+
+				Until op=1 Or occurance=1 'Stop without checking the whole list if we know it was the last one
+
+			End 
+
+			nodeItem=nodeItem.Succ
+
+		lp-=1
+		Until lp=0
+
+		Return currList
+	End
+
+	#rem wonkeydoc Finds the first node in the list containing a value.
+	@param value The value to find.
+	@return The first node containing the value, or null if the value was not found.
+	#end	
+	Method Contains:Node( value:T ) 'Added by iDkP from GaragePixel
+		'iDkP: Added as sugar for front-end consistance with map
+		Return FindNode(value)
+	End
+
+	#rem wonkeydoc Add each keys from this (param) to self
+	@param This The list to compare.
+	@param onPlace if False, returns a copy of the list, else nothing
+	#end
+	Method Append:List<T>(this:List<T>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
+		'Sugar
+		If onPlace 
+			Self.AddAll(this)
+			Return Null
+		End
+		Local result:=Copy()
+		result.AddAll(this)
+		Return result
+	End
+
+	#rem wonkeydoc Add each item from this (param) that exist in self. 
+
+	Each item will be unique and in the same order from the two original lists. 
+
+	Note: Make also unique the items in the two original list.
+
+	@param This The list to compare.
+
+	@param onPlace if False, returns a copy of the list, else nothing
+
+	#end	
+	Method Union:List<T>(this:List<T>,onPlace:Bool=True) Where T=IReal Or T=INumeric Or T=String Or T=Byte Or T=Bool Or T=Variant 'Added by iDkP from GaragePixel
+		'
+		' iDkP from GaragePixel
+		' 2025-05-10 - Original algorithm for stdlib: 
+		' https://github.com/GaragePixel/stdlib-for-mx2/tree/main
+		'
+		' Description:
+		' 	Add this to self, do not keep doublons in the output list.
+		'
+		' Note:
+		' 	Hyper fast algorithm using the red-black tree implementation of map (see note under)
+		'		Source red-black tree: https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
+		'
+		' 	This method only takes internal type because:
+		' 		- To make a key from map, the type must be an internal type, not a custom type,
+		'
+		If onPlace 
+			Self.AddAll(this)
+
+			'--------------------------
+			'
+			'Strange bug:  
+			'	Can't find overload for 'MakeUnique' with argument types (monkey.types.Bool)
+			'
+			'Return MakeUnique(True) 'Strange bug:  Can't find overload for 'MakeUnique' with argument types (monkey.types.Bool)
+			'
+			'--------------------------
+
+			' Need to un-inlined because the strange bug
+			Local map:=New Map<T,UInt>() 'Hash Key calculated from the T value, value as 32 bit marked
+			Local listItem:List<T>.Node=FirstNode() 'A node from List
+			Local listValue:T 'A value from List
+			Local value:UInt '32 bit marker
+			Local out:=New List<T> 'pruned list
+			Local op:UInt 'The list is defined as quasicircular (no root, but floating head) so we need a tracker
+			
+			'Map the values and note how many times they appear in the list
+			Repeat
+				
+				listValue=map.Get(listItem.Value)
+				
+				If listValue<>Null
+					map.Set(listItem.Value,map.Get(listItem.Value)+1)
+				End
+				
+				listItem=listItem.Succ
+				op+=1
+				
+			Until listItem=HeadNode()
+			
+			'As a backward iteration, put the value marked 1 in the out list, otherwise decrement
+			listItem=LastNode()
+			Repeat
+				
+				value=map.Get(listItem.Value)
+				
+				If value=1
+					out.AddFirst(listItem.Value)
+				Else 
+					map.Set(listItem.Value,value-1)
+				End 
+				
+				listItem=listItem.Pred
+				op-=1
+				
+			Until op=0
+			
+			'Finaly, directly set self
+			_head=out._head
+				
+			Return Null
+			
+		End 'onPlace version
+		
+		'------------------------- "returns a copy of the list" Version
+		
+		Local result:=Copy()
+		result.AddAll(this)
+
+		'--------------------------
+		'
+		'Strange bug:  
+		'	Can't find overload for 'MakeUnique' with argument types (monkey.types.Bool)
+		'
+		'result.MakeUnique(True) 
+		'Return result
+		'--------------------------
+
+		' Need to un-inlined because the strange bug
+		Local map:=New Map<T,UInt>() 'Hash Key calculated from the T value, value as 32 bit marked
+		Local listItem:List<T>.Node=result.FirstNode() 'A node from List
+		Local listValue:T 'A value from List
+		Local value:UInt '32 bit marker
+		Local out:=New List<T> 'pruned list
+		Local op:UInt 'The list is defined as quasicircular (no root, but floating head) so we need a tracker
+		
+		'Map the values and note how many times they appear in the list
+		Repeat
+			
+			listValue=map.Get(listItem.Value)
+			
+			If listValue<>Null
+				map.Set(listItem.Value,map.Get(listItem.Value)+1)
+			End
+			
+			listItem=listItem.Succ
+			op+=1
+			
+		Until listItem=result.HeadNode()
+		
+		'As a backward iteration, put the value marked 1 in the out list, otherwise decrement
+		listItem=result.LastNode()
+		Repeat
+			
+			value=map.Get(listItem.Value)
+			
+			If value=1
+				out.AddFirst(listItem.Value)
+			Else 
+				map.Set(listItem.Value,value-1)
+			End 
+			
+			listItem=listItem.Pred
+			op-=1
+			
+		Until op=0
+		
+		'Finaly, return result
+		Return out
+	End
+
+	#rem wonkeydoc Keep all keys from self that exist in this (param)
+
+	@param This The list to compare.
+
+	@param onPlace if False, returns a copy of the list, else nothing
+
+	#end	
+	Method Intersect:List<T>(this:List<T>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
+		'Keep in self the keys that exist in this
+		If onPlace 
+			For Local item:= Eachin Self
+				If this.FindNode(item)=Null Self.RemoveEach(item)
+			End
+			Return Null
+		End 
+		Local result:=Copy()
+		For Local item:= Eachin result
+			If this.FindNode(item)=Null result.RemoveEach(item)
+		End 	
+		Return result	
+	End
+
+	#rem wonkeydoc Remove all keys from self that exist in this (param)
+
+	@param This The list to compare.
+
+	@param onPlace if False, returns a copy of the list, else nothing
+
+	#end
+	Method Diff:List<T>( this:List<T>, onPlace:Bool=True ) 'Added by iDkP from GaragePixel
+		'Remove all keys from self that exist in this
+		If onPlace 
+			For Local item:= Eachin Self
+				If this.FindNode(item)<>Null Self.RemoveEach(item)
+			End
+			Return Null
+		End 
+		Local result:=Copy()
+		For Local item:= Eachin result
+			If this.FindNode(item)<>Null result.RemoveEach(item)
+		End 	
+		Return result		
+	End
 End

--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -490,6 +490,72 @@ Class Map<K,V>
 		Return True
 	End
 
+	#rem monkeydoc Union: Add each keys from this (param) that exist in self
+	@param This The map to compare.
+	@param onPlace if False, returns a copy of the map, else nothing
+	#end
+	Method Append:Map<K,V>(this:Map<K,V>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
+		'Sugar
+		Return Union(this,onPlace)
+	End
+	
+	#rem monkeydoc Union: Add each keys from this (param) that exist in self
+	@param This The map to compare.
+	@param onPlace if False, returns a copy of the map, else nothing
+	#end	
+	Method Union:Map<K,V>(this:Map<K,V>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
+		'Add this to self
+		If onPlace 
+			For Local item:= Eachin this
+				Set(item.Key,item.Value)
+			Next
+			Return Null 
+		End
+		Local result:=Copy()
+		For Local item:= Eachin this
+			result.Set(item.Key,item.Value)
+		End
+		Return result
+	End 
+
+	#rem monkeydoc Intersect: Keep all keys from self that exist in this (param)
+	@param This The map to compare.
+	@param onPlace if False, returns a copy of the map, else nothing
+	#end	
+	Method Intersect:Map<K,V>(this:Map<K,V>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
+		'Keep in self the keys that exist in this
+		If onPlace 
+			For Local item:= Eachin Self
+				If Not this.Contains(item.Key) Self.Remove(item.Key)
+			End 
+			Return Null
+		End 
+		Local result:=Copy()
+		For Local item:= Eachin result
+			If Not this.Contains(item.Key) result.Remove(item.Key)
+		End 	
+		Return result	
+	End
+
+	#rem monkeydoc Difference: Remove all keys from self that exist in this (param)
+	@param This The map to compare.
+	@param onPlace if False, returns a copy of the map, else nothing
+	#end
+	Method Diff:Map<K,V>(this:Map<K,V>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
+		'Remove all keys from self that exist in this
+		If onPlace 
+			For Local item:= Eachin Self
+				If this.Contains(item.Key) Remove(item.Key)
+			End 
+			Return Null
+		End 
+		Local result:=Copy()
+		For Local item:= Eachin result
+			If this.Contains(item.Key) result.Remove(item.Key)
+		End 	
+		Return result	
+	End
+
 	Private
 	
 	Field _root:Node

--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -1,5 +1,5 @@
 
-Namespace stdlib.collections
+Namespace std.collections
 
 #rem wonkeydoc Convenience type alias for Map\<Int,V\>.
 #end

--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -300,16 +300,22 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Gets a view of the map's keys.
+
 	The returned value can be used with an Eachin loop to iterate over the map's keys.
+
 	@return A MapKeys object.
+
 	#end
 	Property Keys:MapKeys()
 		Return New MapKeys( Self )
 	End
 
 	#rem wonkeydoc Gets a view of the map's values.
+
 	The returned value can be used with an Eachin loop to iterate over the map's values.
+
 	@return A MapValues object.
+
 	#end	
 	Property Values:MapValues()
 		Return New MapValues( Self )
@@ -333,7 +339,9 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Gets the number of keys in the map.
+
 	@return The number of keys in the map.
+
 	#end
 	Method Count:Int()
 		If Not _root Return 0
@@ -341,35 +349,50 @@ Class Map<K,V>
 	End
 
 	#rem wonkeydoc Checks if the map is empty.
+
 	@return True if the map is empty.
+
 	#end
 	Property Empty:Bool()
 		Return _root=Null
 	End
 
 	#rem wonkeydoc Checks if the map contains a given key.
+
 	@param key The key to check for.
+
 	@return True if the map contains the key.
+
 	#end
 	Method Contains:Bool( key:K )
 		Return FindNode( key )<>Null
 	End
 	
 	#rem wonkeydoc Sets the value associated with a key in the map.
+
 	If the map does not contain `key`, a new key/value node is added and true is returned.
+
 	If the map already contains `key`, its associated value is updated and false is returned.
+
 	This operator functions identically to Set.
+
 	@param key The key.
+
 	@param value The value.
+
 	@return True if a new node was added to the map.
+
 	#end
 	Operator[]=( key:K,value:V )
 		Set( key,value )
 	End
 
 	#rem wonkeydoc Gets the value associated with a key in the map.
+
 	@param key The key.
+
 	@return The value associated with `key`, or null if `key` is not in the map.
+
 	#end
 	Operator[]:V( key:K )
 		Local node:=FindNode( key )
@@ -378,11 +401,17 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Sets the value associated with a key in the map.
+
 	If the map does not contain `key`, a new key/value node is added to the map and true is returned.
+
 	If the map already contains `key`, its associated value is updated and false is returned.
+
 	@param key The key.
+
 	@param value The value.
+
 	@return True if a new node was added to the map, false if an existing node was updated.
+
 	#end
 	Method Set:Bool( key:K,value:V )
 		
@@ -424,11 +453,17 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Adds a new key/value pair to a map.
+
 	If the map does not contain `key', a new key/value node is created and true is returned.
+
 	If the map already contains `key`, nothing happens and false is returned.
+
 	@param key The key.
+
 	@param value The value.
+
 	@return True if a new node was added to the map, false if the map was not modified.
+
 	#end
 	Method Add:Bool( key:K,value:V )
 		
@@ -456,11 +491,17 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Updates the value associated with a key in the map.
+
 	If the map does not contain `key', nothing happens and false is returned.
+
 	If the map already contains `key`, its associated value is updated and true is returned.
+
 	@param key The key.
+
 	@param value The value.
+
 	@return True if the value associated with `key` was updated, false if the map was not modified.
+
 	#end
 	Method Update:Bool( key:K,value:V )
 		Local node:=FindNode( key )
@@ -470,8 +511,11 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Gets the value associated with a key in the map.
+
 	@param key The key.
+
 	@return The value associated with the key, or null if the key is not in the map.
+
 	#end
 	Method Get:V( key:K )
 		Local node:=FindNode( key )
@@ -480,8 +524,11 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Removes a key from the map.
+
 	@param key The key to remove.
+
 	@return True if the key was removed, or false if the key is not in the map.
+
 	#end
 	Method Remove:Bool( key:K )
 		Local node:=FindNode( key )
@@ -490,18 +537,24 @@ Class Map<K,V>
 		Return True
 	End
 
-	#rem monkeydoc Union: Add each keys from this (param) that exist in self
-	@param This The map to compare.
+	#rem wonkeydoc Union: Add each keys from this (param) that exist in self
+
+	@param This is the map to compare.
+
 	@param onPlace if False, returns a copy of the map, else nothing
+
 	#end
 	Method Append:Map<K,V>(this:Map<K,V>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Sugar
 		Return Union(this,onPlace)
 	End
 	
-	#rem monkeydoc Union: Add each keys from this (param) that exist in self
-	@param This The map to compare.
+	#rem wonkeydoc Union: Add each keys from this (param) that exist in self
+
+	@param This is the map to compare.
+
 	@param onPlace if False, returns a copy of the map, else nothing
+
 	#end	
 	Method Union:Map<K,V>(this:Map<K,V>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Add this to self
@@ -518,9 +571,12 @@ Class Map<K,V>
 		Return result
 	End 
 
-	#rem monkeydoc Intersect: Keep all keys from self that exist in this (param)
-	@param This The map to compare.
+	#rem wonkeydoc Intersect: Keep all keys from self that exist in this (param)
+
+	@param This is the map to compare.
+
 	@param onPlace if False, returns a copy of the map, else nothing
+
 	#end	
 	Method Intersect:Map<K,V>(this:Map<K,V>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Keep in self the keys that exist in this
@@ -537,9 +593,12 @@ Class Map<K,V>
 		Return result	
 	End
 
-	#rem monkeydoc Difference: Remove all keys from self that exist in this (param)
-	@param This The map to compare.
+	#rem wonkeydoc Difference: Remove all keys from self that exist in this (param)
+
+	@param This is the map to compare.
+
 	@param onPlace if False, returns a copy of the map, else nothing
+
 	#end
 	Method Diff:Map<K,V>(this:Map<K,V>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Remove all keys from self that exist in this

--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -1,5 +1,5 @@
 
-Namespace std.collections
+Namespace stdlib.collections
 
 #rem wonkeydoc Convenience type alias for Map\<Int,V\>.
 #end
@@ -300,22 +300,16 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Gets a view of the map's keys.
-
 	The returned value can be used with an Eachin loop to iterate over the map's keys.
-
 	@return A MapKeys object.
-
 	#end
 	Property Keys:MapKeys()
 		Return New MapKeys( Self )
 	End
 
 	#rem wonkeydoc Gets a view of the map's values.
-
 	The returned value can be used with an Eachin loop to iterate over the map's values.
-
 	@return A MapValues object.
-
 	#end	
 	Property Values:MapValues()
 		Return New MapValues( Self )
@@ -339,9 +333,7 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Gets the number of keys in the map.
-
 	@return The number of keys in the map.
-
 	#end
 	Method Count:Int()
 		If Not _root Return 0
@@ -349,50 +341,35 @@ Class Map<K,V>
 	End
 
 	#rem wonkeydoc Checks if the map is empty.
-
 	@return True if the map is empty.
-
 	#end
 	Property Empty:Bool()
 		Return _root=Null
 	End
 
 	#rem wonkeydoc Checks if the map contains a given key.
-
 	@param key The key to check for.
-
 	@return True if the map contains the key.
-
 	#end
 	Method Contains:Bool( key:K )
 		Return FindNode( key )<>Null
 	End
 	
 	#rem wonkeydoc Sets the value associated with a key in the map.
-
 	If the map does not contain `key`, a new key/value node is added and true is returned.
-
 	If the map already contains `key`, its associated value is updated and false is returned.
-
 	This operator functions identically to Set.
-
 	@param key The key.
-
 	@param value The value.
-
 	@return True if a new node was added to the map.
-
 	#end
 	Operator[]=( key:K,value:V )
 		Set( key,value )
 	End
 
 	#rem wonkeydoc Gets the value associated with a key in the map.
-
 	@param key The key.
-
 	@return The value associated with `key`, or null if `key` is not in the map.
-
 	#end
 	Operator[]:V( key:K )
 		Local node:=FindNode( key )
@@ -401,17 +378,11 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Sets the value associated with a key in the map.
-
 	If the map does not contain `key`, a new key/value node is added to the map and true is returned.
-
 	If the map already contains `key`, its associated value is updated and false is returned.
-
 	@param key The key.
-
 	@param value The value.
-
 	@return True if a new node was added to the map, false if an existing node was updated.
-
 	#end
 	Method Set:Bool( key:K,value:V )
 		
@@ -453,17 +424,11 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Adds a new key/value pair to a map.
-
 	If the map does not contain `key', a new key/value node is created and true is returned.
-
 	If the map already contains `key`, nothing happens and false is returned.
-
 	@param key The key.
-
 	@param value The value.
-
 	@return True if a new node was added to the map, false if the map was not modified.
-
 	#end
 	Method Add:Bool( key:K,value:V )
 		
@@ -491,17 +456,11 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Updates the value associated with a key in the map.
-
 	If the map does not contain `key', nothing happens and false is returned.
-
 	If the map already contains `key`, its associated value is updated and true is returned.
-
 	@param key The key.
-
 	@param value The value.
-
 	@return True if the value associated with `key` was updated, false if the map was not modified.
-
 	#end
 	Method Update:Bool( key:K,value:V )
 		Local node:=FindNode( key )
@@ -511,11 +470,8 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Gets the value associated with a key in the map.
-
 	@param key The key.
-
 	@return The value associated with the key, or null if the key is not in the map.
-
 	#end
 	Method Get:V( key:K )
 		Local node:=FindNode( key )
@@ -524,11 +480,8 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Removes a key from the map.
-
 	@param key The key to remove.
-
 	@return True if the key was removed, or false if the key is not in the map.
-
 	#end
 	Method Remove:Bool( key:K )
 		Local node:=FindNode( key )
@@ -538,11 +491,8 @@ Class Map<K,V>
 	End
 
 	#rem wonkeydoc Union: Add each keys from this (param) that exist in self
-
-	@param This is the map to compare.
-
+	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
-
 	#end
 	Method Append:Map<K,V>(this:Map<K,V>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Sugar
@@ -550,11 +500,8 @@ Class Map<K,V>
 	End
 	
 	#rem wonkeydoc Union: Add each keys from this (param) that exist in self
-
-	@param This is the map to compare.
-
+	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
-
 	#end	
 	Method Union:Map<K,V>(this:Map<K,V>,onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Add this to self
@@ -572,11 +519,8 @@ Class Map<K,V>
 	End 
 
 	#rem wonkeydoc Intersect: Keep all keys from self that exist in this (param)
-
-	@param This is the map to compare.
-
+	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
-
 	#end	
 	Method Intersect:Map<K,V>(this:Map<K,V>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Keep in self the keys that exist in this
@@ -594,11 +538,8 @@ Class Map<K,V>
 	End
 
 	#rem wonkeydoc Difference: Remove all keys from self that exist in this (param)
-
-	@param This is the map to compare.
-
+	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
-
 	#end
 	Method Diff:Map<K,V>(this:Map<K,V>, onPlace:Bool=True) 'Added by iDkP from GaragePixel
 		'Remove all keys from self that exist in this
@@ -870,5 +811,64 @@ Class Map<K,V>
 			parent[0]._left=node[0]
 		End
 		InsertFixup( node )
+	End
+
+	' Extension: Sort With Filter
+	' iDkP from GaragePixel
+	' 2025-01
+	'
+	' The filter is just a Variant passed to the Sort in such way
+	' it can be within the compare function's scope. So we can use
+	' some extra parameters and tests in the compare function
+	' in order to turn it as a filter.
+	'
+	' It was an extension, so for to access to the private content,
+	' it was used Self a lot.
+	'
+	' TODO: Replace Self with the private variables?
+
+	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ) )
+		Sort( filter,compare,0,Length-1 )
+	End
+
+	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ),lo:Int,hi:Int )
+	
+		If hi<=lo Return
+		
+		If lo+1=hi
+			If compare( Self[hi],Self[lo] )<0 Swap( hi,lo )
+			Return
+		Endif
+		
+		Local i:=(lo+hi)/2
+		
+		If compare( Self[i],Self[lo] )<0 Swap( i,lo )
+
+		If compare( Self[hi],Self[i] )<0
+			Swap( hi,i )
+			If compare( Self[i],Self[lo] )<0 Swap( i,lo )
+		Endif
+		
+		Local x:=lo+1
+		Local y:=hi-1
+		Repeat
+			Local p:=Self[i]
+			While compare( Self[x],p )<0
+				x+=1
+			Wend
+			While compare( p,Self[y] )<0
+				y-=1
+			Wend
+			If x>y Exit
+			If x<y
+				Swap( x,y )
+				If i=x i=y Else If i=y i=x
+			Endif
+			x+=1
+			y-=1
+		Until x>y
+
+		Sort( filter,compare,lo,y )
+		Sort( filter,compare,x,hi )
 	End
 End

--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -159,12 +159,10 @@ Class Map<K,V>
 			Return parent
 		End
 		
-		Method Copy:Node( parent:Node Ptr )
-			'Modified by iDkP
-			'Use pointer for passing per cascade and by reference the item to copy
-			Local node:=New Node( _key,_value,_color,parent[0] )
-			If _left node._left=_left.Copy( Varptr(node) )
-			If _right node._right=_right.Copy( Varptr(node) )
+		Method Copy:Node( parent:Node )
+			Local node:=New Node( _key,_value,_color,parent )
+			If _left node._left=_left.Copy( node )
+			If _right node._right=_right.Copy( node )
 			Return node
 		End
 	
@@ -257,7 +255,7 @@ Class Map<K,V>
 	Struct MapKeys
 	
 		Method All:KeyIterator()
-			Return New KeyIterator( _map.FirstNode() )
+			Return New KeyIterator( _map.FirstNode )
 		End
 		
 		Private
@@ -273,7 +271,7 @@ Class Map<K,V>
 	Struct MapValues
 	
 		Method All:ValueIterator()
-			Return New ValueIterator( _map.FirstNode() )
+			Return New ValueIterator( _map.FirstNode )
 		End
 		
 		Private
@@ -296,7 +294,7 @@ Class Map<K,V>
 	#end
 	
 	Method All:Iterator()
-		Return New Iterator( FirstNode() )
+		Return New Iterator( FirstNode )
 	End
 	
 	#rem wonkeydoc Gets a view of the map's keys.
@@ -375,6 +373,15 @@ Class Map<K,V>
 		Local node:=FindNode( key )
 		If Not node Return Null
 		Return node._value
+	End
+	
+	Operator To:List<V>()
+		'Set a list of values (negligates the keys)
+		Local list:=New List<V>()
+		For Local item:=Eachin Self 
+			list.Add(item.Value)
+		End
+		Return list
 	End
 	
 	#rem wonkeydoc Sets the value associated with a key in the map.
@@ -555,7 +562,7 @@ Class Map<K,V>
 		End 	
 		Return result	
 	End
-
+	
 	Private
 	
 	Field _root:Node
@@ -565,7 +572,7 @@ Class Map<K,V>
 		_root=root
 	End
 
-	Method LastNode:Node()
+	Property LastNode:Node() 'iDkP: passed public for special iterator, and as property for consistancy
 		If Not _root Return Null
 
 		Local node:=_root
@@ -575,7 +582,7 @@ Class Map<K,V>
 		Return node
 	End
 
-	Method FirstNode:Node()
+	Property FirstNode:Node() 'iDkP: passed to public for special iterator, and as property for consistancy
 		If Not _root Return Null
 
 		Local node:=_root
@@ -689,7 +696,7 @@ Class Map<K,V>
 		node._parent=child
 	End
 	
-	Method InsertFixup( node:Node Ptr ) 'iDkP from GaragePixe: pointer usage
+	Method InsertFixup( node:Node Ptr ) 'iDkP from GaragePixel: pointer usage
 		While node[0]._parent And node[0]._parent._color=ColorRed And node[0]._parent._parent
 			If node[0]._parent=node[0]._parent._parent._left
 				Local uncle:=node[0]._parent._parent._right
@@ -811,64 +818,5 @@ Class Map<K,V>
 			parent[0]._left=node[0]
 		End
 		InsertFixup( node )
-	End
-
-	' Extension: Sort With Filter
-	' iDkP from GaragePixel
-	' 2025-01
-	'
-	' The filter is just a Variant passed to the Sort in such way
-	' it can be within the compare function's scope. So we can use
-	' some extra parameters and tests in the compare function
-	' in order to turn it as a filter.
-	'
-	' It was an extension, so for to access to the private content,
-	' it was used Self a lot.
-	'
-	' TODO: Replace Self with the private variables?
-
-	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ) )
-		Sort( filter,compare,0,Length-1 )
-	End
-
-	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ),lo:Int,hi:Int )
-	
-		If hi<=lo Return
-		
-		If lo+1=hi
-			If compare( Self[hi],Self[lo] )<0 Swap( hi,lo )
-			Return
-		Endif
-		
-		Local i:=(lo+hi)/2
-		
-		If compare( Self[i],Self[lo] )<0 Swap( i,lo )
-
-		If compare( Self[hi],Self[i] )<0
-			Swap( hi,i )
-			If compare( Self[i],Self[lo] )<0 Swap( i,lo )
-		Endif
-		
-		Local x:=lo+1
-		Local y:=hi-1
-		Repeat
-			Local p:=Self[i]
-			While compare( Self[x],p )<0
-				x+=1
-			Wend
-			While compare( p,Self[y] )<0
-				y-=1
-			Wend
-			If x>y Exit
-			If x<y
-				Swap( x,y )
-				If i=x i=y Else If i=y i=x
-			Endif
-			x+=1
-			y-=1
-		Until x>y
-
-		Sort( filter,compare,lo,y )
-		Sort( filter,compare,x,hi )
 	End
 End

--- a/modules/std/collections/stack.wx
+++ b/modules/std/collections/stack.wx
@@ -811,5 +811,63 @@ Class Stack<T> Implements IContainer<T>
 	Method Join:String( separator:String ) Where T=String
 		Return separator.Join( ToArray() )
 	End
+
+	' Extension: Sort With Filter
+	' iDkP from GaragePixel
+	' 2025-01
+	'
+	' The filter is just a Variant passed to the Sort in such way
+	' it can be within the compare function's scope. So we can use
+	' some extra parameters and tests in the compare function
+	' in order to turn it as a filter.
+	'
+	' It was an extension, so for to access to the private content,
+	' it was used Self a lot.
+	'
+	' TODO: Replace Self with the private variables?
+
+	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ) )
+		Sort( filter,compare,0,Length-1 )
+	End
+
+	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ),lo:Int,hi:Int )
 	
+		If hi<=lo Return
+		
+		If lo+1=hi
+			If compare( Self[hi],Self[lo] )<0 Swap( hi,lo )
+			Return
+		Endif
+		
+		Local i:=(lo+hi)/2
+		
+		If compare( Self[i],Self[lo] )<0 Swap( i,lo )
+
+		If compare( Self[hi],Self[i] )<0
+			Swap( hi,i )
+			If compare( Self[i],Self[lo] )<0 Swap( i,lo )
+		Endif
+		
+		Local x:=lo+1
+		Local y:=hi-1
+		Repeat
+			Local p:=Self[i]
+			While compare( Self[x],p )<0
+				x+=1
+			Wend
+			While compare( p,Self[y] )<0
+				y-=1
+			Wend
+			If x>y Exit
+			If x<y
+				Swap( x,y )
+				If i=x i=y Else If i=y i=x
+			Endif
+			x+=1
+			y-=1
+		Until x>y
+
+		Sort( filter,compare,lo,y )
+		Sort( filter,compare,x,hi )
+	End	
 End

--- a/modules/std/collections/stack.wx
+++ b/modules/std/collections/stack.wx
@@ -1,5 +1,5 @@
 
-Namespace std.collections
+Namespace stdlib.collections
 
 #rem wonkeydoc Convenience type alias for Stack\<Int\>.
 #end
@@ -13,7 +13,10 @@ Alias FloatStack:Stack<Float>
 #end
 Alias StringStack:Stack<String>
 
-#rem wonkeydoc The Stack class provides suport for dynamic arrays.
+Alias StackSortFilter:Variant 	' A variant you can pass trough the Sort function.
+								' See the Sort With Filter extension by iDkP from GaragePixel
+
+#rem wonkeydoc The Stack class provides support for dynamic arrays.
 
 A stack is an 'array like' container that grows dynamically as necessary.
 
@@ -869,5 +872,5 @@ Class Stack<T> Implements IContainer<T>
 
 		Sort( filter,compare,lo,y )
 		Sort( filter,compare,x,hi )
-	End	
+	End
 End

--- a/modules/std/collections/stack.wx
+++ b/modules/std/collections/stack.wx
@@ -1,5 +1,5 @@
 
-Namespace stdlib.collections
+Namespace std.collections
 
 #rem wonkeydoc Convenience type alias for Stack\<Int\>.
 #end


### PR DESCRIPTION
**For List:**

- Append: Combine items from two lists (keeping dups) → ~25M-33M elements/second
- Union: Combine unique items from two lists (removing dups) → 558K-943K elements/second
- Intersect: Extract common items between two lists → 649K-1.06M elements/second
- Diff: Extract items present in the first list but not in the second → 495K-813K elements/second
- Dedup: Removes all duplicates preserving first occurrence → 714K to 1.43M elements/second
- All operations support in-place modification or new list creation
- Compatible with built-in types (IReal, INumeric, String, Byte, Bool... ) and custom type.
- Three properties: HasOne, HasTwo, HasOneOrTwo
- Useful methods: Copy, HasMore, HasLess
- Operator: To:Map (Implicit and explicit casting map<-list to key or value)
- Explicit conversions: ToMapByte, ToMapUByte, ToMapInt, ToMapUInt, ToMapLong, ToMapULong, FromMap
*the datatype for the ToMap explicite conversion methods in related to optional indexing*
- and some optimizations... I'm currently using an AMD Ryzen 5 3600 6-core processor clocked at 3.60 GHz (2019's technology), so I'm interested in the results of other machines. With present-day tech, it should be 3-4 times faster than my results.

**For Stack:**

- I will push an urgent mini-lib from Monkey/GaragePixel's stdlib into Wonkey's Stack about Sorting with Filter. 