### PR TITLE
Garage pixel rect additions

### DIFF
--- a/modules/std/collections/stack.wx
+++ b/modules/std/collections/stack.wx
@@ -17,13 +17,9 @@ Alias StackSortFilter:Variant 	' A variant you can pass trough the Sort function
 								' See the Sort With Filter extension by iDkP from GaragePixel
 
 #rem wonkeydoc The Stack class provides support for dynamic arrays.
-
 A stack is an 'array like' container that grows dynamically as necessary.
-
 It is very cheap to add values to the end of a stack, but insertion or removal of values requires higher indexed values to be 'shifted' up or down so is slower.
-
 Stacks implement the [[IContainer]] interface so can be used with Eachin loops.
-
 #end
 Class Stack<T> Implements IContainer<T>
 
@@ -34,13 +30,13 @@ Class Stack<T> Implements IContainer<T>
 		Private
 
 		Field _stack:Stack
-		Field _index:Int
+		Field _index:Int 'iDkP: 32 bits!
 		
 		Method AssertCurrent()
 			DebugAssert( _index<_stack._length,"Invalid stack iterator" )
 		End
-		
-		Method New( stack:Stack,index:Int )
+
+		Method New( stack:Stack,index:Int ) 'iDkP: 32 bits!
 			_stack=stack
 			_index=index
 		End
@@ -71,11 +67,8 @@ Class Stack<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely erases the value pointed to by the iterator.
-		
 		After calling this method, the iterator will point to the value after the removed value.
-		
 		Therefore, if you are manually iterating through a stack you should not call [[Bump]] after calling this method or you will end up skipping a value.
-		
 		#end
 		Method Erase()
 			AssertCurrent()
@@ -83,9 +76,7 @@ Class Stack<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely inserts a value before the value pointed to by the iterator.
-
 		After calling this method, the iterator will point to the newly added value.
-		
 		#end
 		Method Insert( value:T )
 			DebugAssert( _index<=_stack._length,"Invalid stack iterator" )
@@ -100,13 +91,14 @@ Class Stack<T> Implements IContainer<T>
 		Private
 
 		Field _stack:Stack
-		Field _index:Int
+		'Field _index:UInt 'iDkP: UNSIGNED 32 bits!
+		Field _index:Int 'iDkP: 32 bits!
 		
 		Method AssertCurrent()
 			DebugAssert( _index>=0,"Invalid stack iterator" )
 		End
 		
-		Method New( stack:Stack,index:Int )
+		Method New( stack:Stack,index:Int ) 'iDkP: 32 bits!
 			_stack=stack
 			_index=index
 		End
@@ -137,12 +129,9 @@ Class Stack<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely erases the value pointed to by the iterator.
-		
 		After calling this method, the iterator will point to the value after the removed value.
-		
 		Therefore, if you are manually iterating through a stack you should not call [[Bump]] after calling this method or you
 		will end up skipping a value.
-		
 		#end
 		Method Erase()
 			AssertCurrent()
@@ -151,9 +140,7 @@ Class Stack<T> Implements IContainer<T>
 		End
 		
 		#rem wonkeydoc Safely inserts a value before the value pointed to by the iterator.
-
 		After calling this method, the iterator will point to the newly added value.
-		
 		#end
 		Method Insert( value:T )
 			DebugAssert( _index<_stack._length,"Invalid stack iterator" )
@@ -165,34 +152,25 @@ Class Stack<T> Implements IContainer<T>
 	Private
 
 	Field _data:T[]
-	Field _length:Int
+	Field _length:Int 'iDkP: 32 bits!
 	
 	Public
 	
 	#rem wonkeydoc Creates a new stack.
-	
 	New() creates an empty stack.
-	
 	New( length:Int ) creates a stack that initially contains `length` null values.
-	
 	New( values:T[] ) creates a stack with the contents of an array.
-	
 	New( values:List<T> ) creates a stack with the contents of a list.
-	
 	New( values:Deque<T> ) create a stack with the contents of a deque.
-	
 	New( values:Stack<T> ) create a stack with the contents of another stack.
-	
 	@param length The length of the stack.
-	
 	@param values An array, list or stack.
-	
 	#end
 	Method New()
 		_data=New T[10]
 	End
-	
-	Method New( length:Int )
+
+	Method New( length:Int ) 'iDkP: 32 bits!
 		_length=length
 		_data=New T[_length]
 	End
@@ -218,78 +196,67 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Checks if the stack is empty.
-	
 	@return True if the stack is empty.
-	
 	#end
 	Property Empty:Bool()
 		Return _length=0
 	End
 
+	Property First:T()
+		Return Self.Empty ? Null Else Self[0]
+	End
+	
+	Property Last:T()
+		Return Self.Empty ? Null Else Self[Self.Length-1]
+	End
+
 	#rem wonkeydoc Gets an iterator for visiting stack values.
-	
 	Returns an iterator suitable for use with Eachin, or for manual iteration.
-	
 	@return A stack iterator.
-	
 	#end
 	Method All:Iterator()
 		Return New Iterator( Self,0 )
 	End
 	
 	#rem wonkeydoc Gets an iterator for visiting stack values in reverse order.
-	
 	Returns an iterator suitable for use with Eachin, or for manual iteration.
-
 	@return A backwards stack iterator.
-		
 	#end	
 	Method Backwards:BackwardsIterator()
 		Return New BackwardsIterator( Self,_length-1 )
 	End
 
 	#rem wonkeydoc Converts the stack to an array.
-	
 	@return An array containing each element of the stack.
-	
 	#end
 	Method ToArray:T[]()
 		Return _data.Slice( 0,_length )
 	End
 	
 	#rem wonkeydoc Gets the underlying array used by the stack.
-	
 	Note that the returned array may be longer than the stack length.
-	
 	@return The array used internally by the stack.
-	
 	#end
 	Property Data:T[]()
 		Return _data
 	End
 	
 	#rem wonkeydoc Gets the number of values in the stack.
-	
 	@return The number of values in the stack.
-	
 	#end
-	Property Length:Int()
+	Property Length:Int() 'iDkP: 32 bits!
 		Return _length
 	End
 	
 	#rem wonkeydoc Gets the storage capacity of the stack.
-	
 	The capacity of a stack is the number of values it can contain before memory needs to be reallocated to store more values.
-	
 	If a stack's length equals its capacity, then the next Add or Insert operation will need to allocate more memory to 'grow' the stack.
-	
 	You don't normally need to worry about stack capacity, but it can be useful to use [[Reserve]] to preallocate stack storage if you know in advance
 	how many values a stack is likely to contain, in order to prevent the overhead of excessive memory allocation.
-	
 	@return The current stack capacity.
-	
 	#end
-	Property Capacity:Int()
+
+	Property Capacity:Int() 'iDkP: 32 bits!
 		Return _data.Length
 	End
 	
@@ -300,15 +267,12 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Resizes the stack.
-	
 	If `length` is greater than the current stack length, any extra elements are initialized to null.
-	
 	If `length` is less than the current stack length, the stack is truncated.
-	
 	@param length The new length of the stack.
-	
-	#end	
-	Method Resize( length:Int )
+	#end
+	Method Resize( length:Int ) 'iDkP: 32 bits!
+		
 		DebugAssert( length>=0 )
 		
 		For Local i:=length Until _length
@@ -320,23 +284,21 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Reserves stack storage capacity.
-	
 	The capacity of a stack is the number of values it can contain before memory needs to be reallocated to store more values.
-	
 	If a stack's length equals its capacity, then the next Add, Insert or Push operation will need to allocate more memory to 'grow' the stack.
-	
 	You don't normally need to worry about stack capacity, but it can be useful to use [[Reserve]] to preallocate stack storage if you know in advance
 	how many values a stack is likely to contain, in order to prevent the overhead of excessive memory allocation.
-	
 	@param capacity The new capacity.
-	
 	#end
-	Method Reserve( capacity:Int )
+	Method Reserve( capacity:Int ) 'iDkP: 32 bits!
+		
 		DebugAssert( capacity>=0 )
 		
 		If _data.Length>=capacity Return
 		
-		capacity=Max( _length*2,capacity )
+		'capacity=Max( _length*2,capacity )
+		capacity=_length*2 > capacity ? _length*2 Else capacity 'Modified by iDkP
+		
 		Local data:=New T[capacity]
 		_data.CopyTo( data,0,0,_length )
 		_data=data
@@ -349,16 +311,14 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Erases an element at an index in the stack.
-	
 	In debug builds, a runtime error will occur if `index` is less than 0 or greater than the stack length.
-	
 	if `index` is equal to the stack length, the operation has no effect.
-	
 	@param index The index of the element to erase.
-	
 	#end
-	Method Erase( index:Int )
+	Method Erase( index:Int ) 'iDkP: 32 bits!
+		
 		DebugAssert( index>=0 And index<=_length )
+		
 		If index=_length Return
 		
 		_data.CopyTo( _data,index+1,index,_length-index-1 )
@@ -366,17 +326,13 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Erases a range of elements in the stack.
-	
 	If debug builds, a runtime error will occur if either index is less than 0 or greater than the stack length, or if index2 is less than index1.
-	
 	The number of elements actually erased is `index2`-`index1`.
-	
 	@param index1 The index of the first element to erase.
-	
 	@param index2 The index of the last+1 element to erase.
-	
 	#end
-	Method Erase( index1:Int,index2:Int )
+	Method Erase( index1:Int,index2:Int ) 'iDkP: 32 bits!
+		
 		DebugAssert( index1>=0 And index1<=_length And index2>=0 And index2<=_length And index1<=index2 )
 		
 		If index1=_length Return
@@ -385,17 +341,13 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Inserts a value at an index in the stack.
-	
 	In debug builds, a runtime error will occur if `index` is less than 0 or greater than the stack length.
-	
 	If `index` is equal to the stack length, the value is added to the end of the stack.
-	
 	@param index The index of the value to insert.
-	
 	@param value The value to insert.
-	
 	#end
-	Method Insert( index:Int,value:T )
+	Method Insert( index:Int,value:T ) 'iDkP: 32 bits!
+		
 		DebugAssert( index>=0 And index<=_length )
 		
 		Reserve( _length+1 )
@@ -405,78 +357,85 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Gets the value of a stack element.
-	
 	In debug builds, a runtime error will occur if `index` is less than 0, or greater than or equal to the length of the stack.
-	
 	@param index The index of the element to get.
-	
 	#end
-	Method Get:T( index:Int )
+	Method Get:T( index:Int ) 'iDkP: 32 bits!
+		
 		DebugAssert( index>=0 And index<_length,"Stack index out of range" )
 		
 		Return _data[index]
 	End
 	
 	#rem wonkeydoc Sets the value of a stack element.
-
 	In debug builds, a runtime error will occur if `index` is less than 0, or greater than or equal to the length of the stack.
-	
 	@param index The index of the element to set.
-	
 	@param value The value to set.
-	
 	#end
-	Method Set( index:Int,value:T )
+	Method Set( index:Int,value:T ) 'iDkP: 32 bits!
+		
 		DebugAssert( index>=0 And index<_length,"Stack index out of range" )
 		
 		_data[index]=value
 	End
 	
 	#rem wonkeydoc Gets the value of a stack element.
-	
 	In debug builds, a runtime error will occur if `index` is less than 0, or greater than or equal to the length of the stack.
-	
 	@param index The index of the element to get.
-
 	#end
-	Operator []:T( index:Int )
+	Operator []:T( index:Int ) 'iDkP: 32 bits!
+	
 		DebugAssert( index>=0 And index<_length,"Stack index out of range" )
 		
 		Return _data[index]
 	End
 	
 	#rem wonkeydoc Sets the value of a stack element.
-	
 	In debug builds, a runtime error will occur if `index` is less than 0, or greater than or equal to the length of the stack.
-	
 	@param index The index of the element to set.
-	
 	@param value The value to set.
-	
 	#end
-	Operator []=( index:Int,value:T )
+	Operator []=( index:Int,value:T ) 'iDkP: 32 bits!
+	
 		DebugAssert( index>=0 And index<_length,"Stack index out of range" )
 		
 		_data[index]=value
 	End
 	
+	Operator+=( item:T )
+		
+		Self.Add( item )
+	End
+	
+	Operator-=( item:T )
+	
+		Self.Remove( item )
+	End
+	
+	Operator+=( items:T[] )
+	
+		Self.AddAll( items )
+	End
+	
 	#rem wonkeydoc Adds a value to the end of the stack.
-	
 	This method behaves identically to Push( value:T ).
-	
 	@param value The value to add.
-	
 	#end
 	Method Add( value:T )
 		Reserve( _length+1 )
 		_data[_length]=value
 		_length+=1
 	End
+
+	#rem wonkeydoc Adds a value to stack that has no other clone.
+	@param value The value to add.
+	#end
+	Method AddUnique( value:T )
+		If Not Self.Contains( value ) Then Self.Add( value )
+	End
 	
 	#rem wonkeydoc Adds the values in an array or container to the end of the stack.
-	
 	@param values The values to add.
-	
 	#end
 	Method AddAll( values:T[] )
 		Reserve( _length+values.Length )
@@ -499,17 +458,13 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Finds the index of the first matching value in the stack.
-	
 	In debug builds, a runtime error will occur if `start` is less than 0 or greater than the length of the stack.
-	
 	@param value The value to find.
-	
 	@param start The starting index for the search.
-	
 	@return The index of the value in the stack, or -1 if the value was not found.
-	
 	#end
-	Method FindIndex:Int( value:T,start:Int=0 )
+	Method FindIndex:Int( value:T,start:Int=0 ) 'iDkP: 32 bits!
+		
 		DebugAssert( start>=0 And start<=_length )
 		
 		Local i:=start
@@ -521,17 +476,13 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Finds the index of the last matching value in the stack.
-	
 	In debug builds, a runtime error will occur if `start` is less than 0 or greater than the length of the stack.
-	
 	@param value The value to find.
-	
 	@param start The starting index for the search.
-	
 	@return The index of the value in the stack, or -1 if the value was not found.
-	
 	#end
-	Method FindLastIndex:Int( value:T,start:Int=0 )
+	Method FindLastIndex:Int( value:T,start:Int=0 ) 'iDkP: 32 bits!
+		
 		DebugAssert( start>=0 And start<=_length )
 		
 		Local i:=_length
@@ -543,26 +494,19 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Checks if the stack contains a value.
-	
 	@param value The value to check for.
-	
 	@return True if the stack contains the value, else false.
-	
 	#end
 	Method Contains:Bool( value:T )
 		Return FindIndex( value )<>-1
 	End
 	
 	#rem wonkeydoc Finds and removes the first matching value from the stack.
-	
 	@param start The starting index for the search.
-	
 	@param value The value to remove.
-	
 	@return True if the value was removed.
-	
 	#end
-	Method Remove:Bool( value:T,start:Int=0 )
+	Method Remove:Bool( value:T,start:Int=0 ) 'iDkP: 32 bits!
 		Local i:=FindIndex( value,start )
 		If i=-1 Return False
 		Erase( i )
@@ -570,15 +514,11 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Finds and removes the last matching value from the stack.
-	
 	@param start The starting index for the search.
-	
 	@param value The value to remove.
-	
 	@return True if the value was removed.
-	
 	#end
-	Method RemoveLast:Bool( value:T,start:Int=0 )
+	Method RemoveLast:Bool( value:T,start:Int=0 ) 'iDkP: 32 bits!
 		Local i:=FindLastIndex( value,start )
 		If i=-1 Return False
 		Erase( i )
@@ -586,19 +526,16 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Finds and removes each matching value from the stack.
-	
 	@param value The value to remove.
-	
 	@return The number of values removed.
-	
-	#end	
-	Method RemoveEach:Int( value:T )
+	#end
+	Method RemoveEach:Int( value:T ) 'iDkP: 32 bits!
 		Local put:=0,n:=0
 		For Local get:=0 Until _length
 			If _data[get]=value 
 				n+=1
 				Continue
-			Endif
+			End
 			_data[put]=_data[get]
 			put+=1
 		Next
@@ -607,19 +544,16 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Removes all values int the stack that fulfill a condition.
-	
 	@param condition The condition to test.
-	
 	@return The number of values removed.
-	
-	#end	
-	Method RemoveIf:Int( condition:Bool( value:T ) )
+	#end
+	Method RemoveIf:Int( condition:Bool( value:T ) ) 'iDkP: 32 bits!
 		Local put:=0,n:=0
 		For Local get:=0 Until _length
 			If condition( _data[get] )
 				n+=1
 				Continue
-			Endif
+			End
 			_data[put]=_data[get]
 			put+=1
 		Next
@@ -628,60 +562,46 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Returns a range of elements from the stack.
-	
 	Returns a slice of the stack consisting of all elements from `index1` until `index2` or the end of the stack.
-	
 	If either index is negative, then it represents an offset from the end of the stack.
-
 	Indices are clamped to the length of the stack, so Slice will never cause a runtime error.
-	
 	@param index1 the index of the first element (inclusive).
-
 	@param index2 the index of the last element (exclusive).
-	
 	@return A new stack.
-	
 	#end
-	Method Slice:Stack( index:Int )
+	Method Slice:Stack( index:Int ) 'iDkP: 32 bits!
 
 		Return Slice( index,_length )
 	End
 
-	Method Slice:Stack( index1:Int,index2:Int )
+	Method Slice:Stack( index1:Int,index2:Int ) 'iDkP: 32 bits!
 
 		If index1<0
-			index1=Max( index1+_length,0 )
-		Else If index1>_length
+			index1=index1+_length > 0 ? index1+_length Else 0 'Modified by iDkP
+		ElseIf index1>_length
 			index1=_length
-		Endif
+		End
 		
 		If index2<0
-			index2=Max( index2+_length,index1 )
-		Else If index2>_length
+			index2=index2+_length > index1 ? index2 Else index1 'Modified by iDkP
+		ElseIf index2>_length
 			index2=_length
-		Else If index2<index1
+		ElseIf index2<index1
 			index2=index1
-		Endif
+		End
 		
 		Return New Stack( _data.Slice( index1,index2 ) )
 	End
 	
 	#rem wonkeydoc Swaps 2 elements in the stack, or 2 stacks.
-	
 	This method can be used to either swap 2 elements in the stack, or 2 entire stacks.
-	
 	In debug builds, a runtime error will occur if `index1` or `index2` is out of range.
-	
 	Swapping entire stacks simply swaps the storage arrays and lengths of the 2 stacks, and is therefore very fast.
-	
 	@param index1 The index of the first element.
-	
 	@param index2 The index of the second element.
-	
 	@param stack The stack to swap with.
-	
 	#end
-	Method Swap( index1:Int,index2:Int )
+	Method Swap( index1:Int,index2:Int ) 'iDkP: 32 bits!
 		DebugAssert( index1>=0 And index1<_length And index2>=0 And index2<_length,"Stack index out of range" )
 		
 		Local t:=_data[index1]
@@ -698,15 +618,10 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Sorts the stack.
-
 	@param ascending True to sort the stack in ascending order, false to sort in descending order.
-	
 	@param compareFunc Function to be used to compare values when sorting.
-	
 	@param lo Index of first value to sort.
-	
-	@param hi Index of last value to sort.
-
+	@param hi Index of last value to sort.@lo Int start index
 	#end
 	Method Sort( ascending:Int=True )
 		If ascending
@@ -717,21 +632,21 @@ Class Stack<T> Implements IContainer<T>
 			Sort( Lambda:Int( x:T,y:T )
 				Return y<=>x
 			End )
-		Endif
+		End
 	End
 
 	Method Sort( compareFunc:Int( x:T,y:T ) )
 		Sort( compareFunc,0,_length-1 )
 	End
 
-	Method Sort( compareFunc:Int( x:T,y:T ),lo:Int,hi:int )
+	Method Sort( compareFunc:Int( x:T,y:T ),lo:Int,hi:Int ) 'iDkP: lo, hi = 32 bits
 	
 		If hi<=lo Return
 		
 		If lo+1=hi
 			If compareFunc( _data[hi],_data[lo] )<0 Swap( hi,lo )
 			Return
-		Endif
+		End
 		
 		Local i:=(lo+hi)/2
 		
@@ -740,7 +655,7 @@ Class Stack<T> Implements IContainer<T>
 		If compareFunc( _data[hi],_data[i] )<0
 			Swap( hi,i )
 			If compareFunc( _data[i],_data[lo] )<0 Swap( i,lo )
-		Endif
+		End
 		
 		Local x:=lo+1
 		Local y:=hi-1
@@ -755,8 +670,8 @@ Class Stack<T> Implements IContainer<T>
 			If x>y Exit
 			If x<y
 				Swap( x,y )
-				If i=x i=y Else If i=y i=x
-			Endif
+				If i=x i=y ElseIf i=y i=x
+			End
 			x+=1
 			y-=1
 		Until x>y
@@ -766,11 +681,8 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Gets the top element of the stack
-	
 	In debug builds, a runtime error will occur if the stack is empty.
-	
 	@return The top element of the stack.
-	
 	#end
 	Property Top:T()
 		DebugAssert( _length,"Stack is empty" )
@@ -779,9 +691,7 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Pops the top element off the stack and returns it.
-	
 	In debug builds, a runtime error will occur if the stack is empty.
-	
 	@return The top element of the stack before it was popped.
 	#end
 	Method Pop:T()
@@ -794,22 +704,16 @@ Class Stack<T> Implements IContainer<T>
 	End
 	
 	#rem wonkeydoc Pushes a value on the stack.
-
 	This method behaves identically to Add( value:T ).
-	
 	@param value The value to push.
-	
 	#end
 	Method Push( value:T )
 		Add( value )
 	End
 
 	#rem wonkeydoc Joins the values in a string stack.
-	
-	@param sepeator The separator to be used when joining values.
-	
+	@param separator The separator to be used when joining values.
 	@return The joined values.
-	
 	#end
 	Method Join:String( separator:String ) Where T=String
 		Return separator.Join( ToArray() )
@@ -829,18 +733,30 @@ Class Stack<T> Implements IContainer<T>
 	'
 	' TODO: Replace Self with the private variables?
 
+	#rem wonkeydoc Sort With Filter.
+	@author iDkP from GaragePixel
+	@since 2025-01-xx
+	The filter is just a Variant passed to the Sort in such way
+	it can be within the compare function's scope. So we can use
+	some extra parameters and tests in the compare function
+	in order to turn it as a filter.
+	@param filter StackSortFilter 
+	@param compareFunc Function to be used to compare values when sorting.
+	@param lo Index of first value to sort.
+	@param hi Index of last value to sort.@lo Int start index
+	#end
 	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ) )
 		Sort( filter,compare,0,Length-1 )
 	End
 
-	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ),lo:Int,hi:Int )
+	Method Sort( filter:StackSortFilter,compare:Int( x:T,y:T ),lo:Int,hi:Int ) 'iDkP: lo, hi = 32 bits
 	
 		If hi<=lo Return
 		
 		If lo+1=hi
 			If compare( Self[hi],Self[lo] )<0 Swap( hi,lo )
 			Return
-		Endif
+		End
 		
 		Local i:=(lo+hi)/2
 		
@@ -849,7 +765,7 @@ Class Stack<T> Implements IContainer<T>
 		If compare( Self[hi],Self[i] )<0
 			Swap( hi,i )
 			If compare( Self[i],Self[lo] )<0 Swap( i,lo )
-		Endif
+		End
 		
 		Local x:=lo+1
 		Local y:=hi-1
@@ -864,7 +780,7 @@ Class Stack<T> Implements IContainer<T>
 			If x>y Exit
 			If x<y
 				Swap( x,y )
-				If i=x i=y Else If i=y i=x
+				If i=x i=y ElseIf i=y i=x
 			Endif
 			x+=1
 			y-=1

--- a/modules/std/geom/rect.wx
+++ b/modules/std/geom/rect.wx
@@ -360,11 +360,31 @@ Struct Rect<T>
 	Method Intersects:Bool( r:Rect )
 		Return r.max.x>min.x And r.min.x<max.x And r.max.y>min.y And r.min.y<max.y
 	End
+
+	#rem wonkeydoc Move the rect.
+	@adapted iDkP 2025-06-02
+	@param dx the new location
+	@param dy the new location
+	#end
+	Method MoveTo( x:T,y:T )
+		Local size:=Self.Size
+		Self.Origin=New Vec2<T>( x,y )
+		Self.Size=size
+	End
+	
+	#rem wonkeydoc Move the rect.
+	@adapted iDkP 2025-06-02
+	@param dx the quantity of mouvement
+	@param dy the quantity of mouvement
+	#end
+	Method MoveBy( dx:T,dy:T ) Where T Implements INumeric 
+		Local size:=Self.Size
+		Self.Origin=Self.Origin+New Vec2<T>( dx,dy )
+		Self.Size=size
+	End
 	
 	#rem wonkeydoc Gets a string describing the rect.
-	
-	Deprecated: Use Operator To:String instead.
-	
+	@deprecated: Use Operator To:String instead.
 	#end
 	Method ToString:String()
 		Return Self
@@ -613,4 +633,3 @@ Function TransformRecti<T>:Recti( rect:Recti,matrix:AffineMat3<T> )
 		
 	Return New Recti( Round( min.x ),Round( min.y ),Round( max.x ),Round( max.y ) )
 End
-


### PR DESCRIPTION
----------------
Map, List, Stack
----------------

	MAP RANGE x2 (Undoned):
		Map can only works with 32 unigned integer

	POINTER:
		Pointers are back.
		There was a problem with pointers to classes, Node as a class of course, but also K and V (internals).
		This problem is now fixed.

	KEY AS Uint, Long and ULong: UNDONED
		Method ToMapUInt:Map<UInt,T>( defValue:UInt=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapLong:Map<Long,T>( defValue:Long=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapULong:Map<ULong,T>( defValue:ULong=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
		Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP

	Conversions who works:
		Operator To:Map<T,UInt>() 'Added by iDkP
		Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP

		Because T is a 32-bit internal pointer (the node) and is a signed integer, so T and Int work, but not Uint, Long, and ULong.		
		The C transpiler can't handle UInt, Long, and ULong as keys for Map (not my fault).

		This was a workaround:
			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756

	Conversions that should works but no (do not working in debug mode only)
		Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP

		Not specific reason found.

	Works:
		Property HasOne:Bool() 'Added by iDkP
		Property HasTwo:Bool() 'Added by iDkP
		Property HasOneOrTwo:Byte() 'Added by iDkP
		Method HasLess:Bool( nbItems:UInt ) 'Added by iDkP
		Method HasMore:Bool( nbItems:UInt ) 'Added by iDkP
		Operator To:Map<T,UInt>() 'Added by iDkP
		Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
		Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP

	The sort filter was not the cause of the problem. 
	The set of combinatorial functions was not the cause of the problem.

----------------
Ted2go/Wide
----------------

	In utils/Utils:
	Recti Extension Undoned and move in rect, making it generic by the way
	Stack operators extension undoned and moved in Stack

Working time for this analysis and debugging: 9pm -> 5am (8 hours uninterrupted)

----------------
Rect
----------------
	Added MoveTo
	Added MoveBy

This original code was developped by:
Co-authored-by: marksibly <marksibly@zohomail.com>
Co-authored-by: seyhajin <seyhajin@gmail.com>
Co-authored-by: D-a-n-i-l-o<D-a-n-i-l-o@users.noreply.github.com.com>
Co-authored-by: engor<engor@yandex.ru>
Co-authored-by: arawkins<arawkins@gmail.com>
Co-authored-by: XANOZOID<XANOZOID@users.noreply.github.com.com>
Co-authored-by: jacereda<jacereda@users.noreply.github.com.com>
Co-authored-by: LucasWolschick<LucasWolschick@users.noreply.github.com.com>
Co-authored-by: abakobo <abakobo@users.noreply.github.com.com>