### PR TITLE
Add new constructors for Map

### DIFF
--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -436,7 +436,7 @@ Class Map<K,V>
 		Next
 	End
 
-	#rem monkeydoc Creates a new map from interleaved key-value pairs (variant array).
+	#rem wonkeydoc Creates a new map from interleaved key-value pairs (variant array).
 	@author iDkP from GaragePixel
 	@since 2025-06-27
 	Creates a map by reading pairs of key and value from a flat Variant[] array.
@@ -449,7 +449,7 @@ Class Map<K,V>
 	#end
 
 #rem TODO: Activate it after TupleKV's integration
-	#rem monkeydoc Creates a map by reading pairs of key and value from an array of TupleKV<K,V>.
+	#rem wonkeydoc Creates a map by reading pairs of key and value from an array of TupleKV<K,V>.
 	@author iDkP from GaragePixel
 	@since 2025-06-27
 	Notes:
@@ -477,7 +477,7 @@ Class Map<K,V>
 		Next
 	End
 
-	#rem monkeydoc Creates a map by reading pairs of key and value from an stack of TupleKV<K,V>.
+	#rem wonkeydoc Creates a map by reading pairs of key and value from an stack of TupleKV<K,V>.
 	@author iDkP from GaragePixel
 	@since 2025-06-30
 	Notes:

--- a/modules/std/collections/map.wx
+++ b/modules/std/collections/map.wx
@@ -450,6 +450,8 @@ Class Map<K,V>
 
 #rem TODO: Activate it after TupleKV's integration
 	#rem monkeydoc Creates a map by reading pairs of key and value from an array of TupleKV<K,V>.
+	@author iDkP from GaragePixel
+	@since 2025-06-27
 	Notes:
 		- Use for dynamic, script-driven bulk creation, config, or interop with dynamic data.
 		- TupleKV<K,V>[] ensures keys/values are strongly typed (unlike Variant[]).
@@ -465,10 +467,37 @@ Class Map<K,V>
 				'         {[two][2]}
 	
 	#end
-
 	Method New( kv:TupleKV<K,V>[] ) 	Where 
 										(K=Object Or K=String Or K=Int Or K=Float Or K=Short Or K=Long Or K=Double Or K=Bool) And
 										(V=Object Or V=String Or V=Int Or V=Float Or V=Short Or V=Long Or V=Double Or V=Bool)
+		Local len:=kv.Length
+
+		For Local i:=0 Until len
+			Add(kv[i].Item1,kv[i].Item2)
+		Next
+	End
+
+	#rem monkeydoc Creates a map by reading pairs of key and value from an stack of TupleKV<K,V>.
+	@author iDkP from GaragePixel
+	@since 2025-06-30
+	Notes:
+		- Use for dynamic, script-driven bulk creation, config, or interop with dynamic data.
+		- Stack<TupleKV<K,V>> ensures keys/values are strongly typed (unlike Variant[]).
+		- More verbose, but you are sure, at least from a generated script, 
+		that the pair is always from the expected type.
+	
+	@example
+		Local m:=New Map<String,Int>(	New Stack<TupleKV<String,Int>>	(	New TupleKV<String,Int>("one"	,1),
+																			New TupleKV<String,Int>("two"	,2),
+																			New TupleKV<String,Int>("three"	,3)	)
+		Print m 'outputs: {[one][1]}
+				'         {[three][3]}
+				'         {[two][2]}
+	
+	#end
+	Method New( kv:Stack<TupleKV<K,V>> )	Where 
+											(K=Object Or K=String Or K=Int Or K=Float Or K=Short Or K=Long Or K=Double Or K=Bool) And
+											(V=Object Or V=String Or V=Int Or V=Float Or V=Short Or V=Long Or V=Double Or V=Bool)
 		Local len:=kv.Length
 
 		For Local i:=0 Until len


### PR DESCRIPTION
Add new constructors for map:

	#rem wonkeydoc Creates a map by reading pairs of key and value from an array of TupleKV<K,V>.
	@author iDkP from GaragePixel
	@since 2025-06-27
	Notes:
		- Use for dynamic, script-driven bulk creation, config, or interop with dynamic data.
		- TupleKV<K,V>[] ensures keys/values are strongly typed (unlike Variant[]).
		- More verbose, but you are sure, at least from a generated script, 
		that the pair is always from the expected type.
	
	@example
		Local m:=New Map<String,Int>(	New TupleKV<String,Int>[]	(	New TupleKV<String,Int>("one"	,1),
																		New TupleKV<String,Int>("two"	,2),
																		New TupleKV<String,Int>("three"	,3)	)
		Print m 'outputs: {[one][1]}
				'         {[three][3]}
				'         {[two][2]}
	
	#end

	#rem wonkeydoc Creates a map by reading pairs of key and value from an stack of TupleKV<K,V>.
	@author iDkP from GaragePixel
	@since 2025-06-30
	Notes:
		- Use for dynamic, script-driven bulk creation, config, or interop with dynamic data.
		- Stack<TupleKV<K,V>> ensures keys/values are strongly typed (unlike Variant[]).
		- More verbose, but you are sure, at least from a generated script, 
		that the pair is always from the expected type.
	
	@example
		Local m:=New Map<String,Int>(	New Stack<TupleKV<String,Int>>	(	New TupleKV<String,Int>("one"	,1),
																			New TupleKV<String,Int>("two"	,2),
																			New TupleKV<String,Int>("three"	,3)	)
		Print m 'outputs: {[one][1]}
				'         {[two][2]}
				'         {[three][3]}
	
	#end