### PR TITLE
Fix doc in Type, add enum in Timer

### DIFF
--- a/modules/std/time/timer.wx
+++ b/modules/std/time/timer.wx
@@ -15,6 +15,16 @@ Using std.fiber
 
 Public
 
+#rem wonkeydoc Timer resolutions
+@author iDkP from GaragePixel
+@since 2025-07-10
+#end
+Enum TimerResolution 
+	Secs
+	Millisecs
+	Microsecs
+End 
+
 #rem wonkeydoc The Timer class.
 #end
 Class Timer

--- a/modules/wonkey/types.wx
+++ b/modules/wonkey/types.wx
@@ -4,8 +4,9 @@ Namespace wonkey.types
 Extern
 
 #rem
-Author: iDkP from GaragePixe
-Since: 2025-07-09
+2025-07-09 Added new numerical hierarchy interfaces
+Author: iDkP from GaragePixel
+Quick Overview:
 	Hierarchy of number representations:
 		INumeric 
 			IIntegral <- ICompact <- IShort
@@ -22,15 +23,15 @@ End
 Interface IIntegral Extends INumeric
 End
 
-#rem monkeydoc Implemented by compact integral numeric types (less than signed 32 bits).
-@author iDkP from GaragePixe
+#rem wonkeydoc Implemented by compact integral numeric types (less than signed 32 bits).
+@author iDkP from GaragePixel
 @since 2025-07-09
 #end
 Interface ICompact Extends IIntegral
 End
 
-#rem monkeydoc Implemented by short integral numeric types (less than signed 16 bits).
-@author iDkP from GaragePixe
+#rem wonkeydoc Implemented by short integral numeric types (less than signed 16 bits).
+@author iDkP from GaragePixel
 @since 2025-07-09
 #end
 Interface IShort Extends ICompact
@@ -47,31 +48,37 @@ Struct @Bool ="wxBool"
 End
 
 #rem wonkeydoc Primitive 8 bit byte type.
+@modified by iDkP from GaragePixel (2025-07-09)
 #end
 Struct @Byte Implements IShort ="wxByte"
 End
 
 #rem wonkeydoc Primitive 8 bit unsigned byte type.
+@modified by iDkP from GaragePixel (2025-07-09)
 #end
 Struct @UByte Implements IShort ="wxUByte"
 End
 
 #rem wonkeydoc Primitive 16 bit short type.
+@modified by iDkP from GaragePixel (2025-07-09)
 #end
 Struct @Short Implements IShort ="wxShort"
 End
 
 #rem wonkeydoc Primitive 16 bit unsigned short type.
+@modified by iDkP from GaragePixel (2025-07-09)
 #end
 Struct @UShort Implements IShort ="wxUShort"
 End
 
 #rem wonkeydoc Primitive 32 bit int type.
+@modified by iDkP from GaragePixel (2025-07-09)
 #end
 Struct @Int Implements ICompact ="wxInt"
 End
 
 #rem wonkeydoc Primitive 32 bit unsigned int type.
+@modified by iDkP from GaragePixel (2025-07-09)
 #end
 Struct @UInt Implements ICompact ="wxUInt"
 End


### PR DESCRIPTION
The enum in Timer allows to build api that gives the choice of the time granularity.